### PR TITLE
add broken json file for Travis demonstration purposes

### DIFF
--- a/participants/marco_emrich.json
+++ b/participants/marco_emrich.json
@@ -1,4 +1,4 @@
-
+{
   "name": "Marco Emrich",
   "company": "webmasters akademie / owl.institute",
   "tags": [ "es6", "tdd", "bdd", "design", "architecture", "fp" ],

--- a/participants/marco_emrich.json
+++ b/participants/marco_emrich.json
@@ -1,0 +1,17 @@
+
+  "name": "Marco Emrich",
+  "company": "webmasters akademie / owl.institute",
+  "tags": [ "es6", "tdd", "bdd", "design", "architecture", "fp" ],
+  "when": {
+    "saturday": true,
+    "sunday": true
+  },
+  "what_is_my_connection_to_javascript": "I'm a teaching about JS, and wrote several (mostly German) JS-Books.",
+  "what_can_i_contribute_to_js_craftcamp": "Sessions about ES6 and RamdaJS",
+  "urls": {
+    "photo": "https://s.gravatar.com/avatar/b7f79bb887d86569d227cbd2cb9f2cb8?s=80",
+    "homepage": "https://www.amazon.de/Marco-Emrich/e/B00BY3UC8C",
+    "github": "https://github.com/marcoemrich",
+    "twitter": "https://twitter.com/marcoemrich"
+  }
+}


### PR DESCRIPTION
I would like to register for JS CraftCamp.    
[X] My Pull Request contains a json file `$firstname_$lastname.json` or `$nickname.json`    
[X] The json file follows the template at https://github.com/jscraftcamp/website/blob/master/participants/_template.json and contains the mandatory fields `name`, `tags`, `when`, `what_is_my_connection_to_javascript` and `what_can_i_contribute_to_js_craftcamp`    
[X] If I can't attend, I will either send another Pull Request removing my json file or an E-Mail with the subject 'UNREGISTER' to team@jscraftcamp.org

