### PR TITLE
Added og-title and image for better facebook share behaviour

### DIFF
--- a/src/_layout.ejs
+++ b/src/_layout.ejs
@@ -1,10 +1,12 @@
-<html>
+<html xmlns:fb="http://ogp.me/ns/fb">
   <head>
     <head>
       <link type="text/css" rel="stylesheet" href="css/materialize.min.css"  media="screen,projection"/>
       <link type="text/css" rel="stylesheet" href="css/prism-customized.css" />
       <link type="text/css" rel="stylesheet" href="css/main.css"  media="screen,projection"/>
       <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+      <meta property="og:title" content="JSCraftCamp - 8+9 October in Munich" />
+      <meta property="og:image" content="https://github.com/jscraftcamp/website/blob/master/src/img/logo.png" />
       <link href="fonts/font-awesome/css/font-awesome.min.css" rel="stylesheet" type="text/css">
       <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     </head>


### PR DESCRIPTION
@lujakob @cko @wolframkriesing : I realized that sharing our webpage link on facebook creates a rather ugly Link Photo (some pixeled letters like 'dece'). I'm trying to fix this here - but since I am no HTML Expert please check if I'm doing the right thing.

I took our Logo image from the Page instead.