### PR TITLE
Add david_neubauer.json

### DIFF
--- a/participants/david_neubauer.json
+++ b/participants/david_neubauer.json
@@ -1,0 +1,17 @@
+{
+  "name": "David Neubauer",
+  "company": "Glomex",
+  "tags": ["testing", "react", "node", "redux"],
+  "when": {
+    "saturday": true,
+    "sunday": true
+  },
+  "what_is_my_connection_to_javascript": "Open minded in using all kinds of technologies and a passionate JavaScript Developer.",
+  "what_can_i_contribute_to_js_craftcamp": "I'm happy to talk/learn about testing. I'd like to learn how to improve workflows like Code Reviews. Happy to share my Podcast subscription.",
+  "tshirt": "M-M",
+  "urls": {
+    "photo": "https://avatars3.githubusercontent.com/u/4222309?v=3&s=466",
+    "github": "https://github.com/davidspinat",
+    "twitter": "https://twitter.com/davidspinat"
+  }
+}


### PR DESCRIPTION
I would like to register for JS CraftCamp.    
- [x] My Pull Request contains a json file `$firstname_$lastname.json` or `$nickname.json`    
- [x] The json file follows the template at https://github.com/jscraftcamp/website/blob/master/participants/_template.json and contains the mandatory fields `name`, `tags`, `when`, `what_is_my_connection_to_javascript` and `what_can_i_contribute`    
- [x] If I can't attend, I will either send another Pull Request removing my json file or an E-Mail with the subject 'UNREGISTER' to team@jscraftcamp.org

