### PR TITLE
registration for JS BarCamp (Stefan Richter)

### DIFF
--- a/participants/stefan_richter.json
+++ b/participants/stefan_richter.json
@@ -1,0 +1,16 @@
+{
+    "name": "Stefan Richter",
+    "company": "BMW Group",
+    "tags": [ "react" ],
+    "when": {
+      "saturday": true,
+      "sunday": false
+    },
+    "what_is_my_connection_to_javascript": "I have very basic knowledge in using JavaScript and want to learn more about it and its eco system.",
+    "what_can_i_contribute": "I can contribute knowledge about crafmenship, TDD, Continuous Integration and DevOps.",
+    "tshirt": "M-M",
+    "urls": {
+      "github": "https://github.com/sealor"
+    }
+}
+


### PR DESCRIPTION
I would like to register for JS CraftCamp.    
- [X] My Pull Request contains a json file `$firstname_$lastname.json` or `$nickname.json`    
- [X] The json file follows the template at https://github.com/jscraftcamp/website/blob/master/participants/_template.json and contains the mandatory fields `name`, `tags`, `when`, `what_is_my_connection_to_javascript` and `what_can_i_contribute`    
- [x] If I can't attend, I will either send another Pull Request removing my json file or an E-Mail with the subject 'UNREGISTER' to team@jscraftcamp.org

