### PR TITLE
Increased harp version to avoid failing build on linux systems

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {},
   "devDependencies": {
     "hamjest": "^2.13.0",
-    "harp": "^0.20.3",
+    "harp": "^0.21.0",
     "hashcode": "^1.0.3",
     "mocha": "^3.0.2",
     "recursive-readdir-sync": "^1.0.6"


### PR DESCRIPTION
#JSCC16 is over - but we should already think about #JSCC17. I had trouble with `npm install`ing the website with the harp version specified - so I updated it to 0.21.0.