### PR TITLE
fix(Start): improve sponsor layout

### DIFF
--- a/src/index.ejs
+++ b/src/index.ejs
@@ -35,6 +35,40 @@
       margin-top: 1em;
     }
   }
+
+  #sponsors .sponsor-logos {
+    display: flex;
+    align-content: center;
+    align-items: center;
+    flex-wrap: wrap;
+    justify-content: space-around;
+  }
+
+  @media only screen and (max-width: 600px) {
+    #sponsors .sponsor-logos {
+      flex-direction: column;
+    }
+    #sponsors .sponsor {
+      margin: 2rem 0;
+      width: 50%;
+      text-align: center;
+    }
+    #sponsors .sponsor img {
+      max-height: 75px;
+    }
+  }
+
+  @media only screen and (min-width: 601px) {
+    #sponsors .sponsor {
+      width: 280px;
+      margin: 2rem;
+      text-align: center;
+    }
+    #sponsors .sponsor img {
+      max-height: 100px;
+    }
+  }
+
 </style>
 
 <div id="logoContainer" class="container logo centered">
@@ -185,41 +219,24 @@
     </div>
   </div>
 
-  <a name="sponsors"></a>
-  <div class="row">
-    <div class="col s12 m12">
+  <div class="row" id="sponsors">
+    <div class="col s12">
       <h4 class="header center <%= public._data.baseColor %>-text">Sponsors</h4>
-      <br />
-      <br />
     </div>
-
-    <div class="col s12 m4">
-      <a href="http://virtual-identity.com/">
+    <div class="col s12 sponsor-logos">
+      <a href="http://virtual-identity.com/" class="sponsor">
         <img class="responsive-img" src="img/vi_logo.jpeg" alt="Virtual Identity AG">
       </a>
-    </div>
-
-    <div class="col s12 m4">
-      <a href="https://www.trustyou.com/">
+      <a href="https://www.trustyou.com/" class="sponsor">
         <img class="responsive-img" src="img/sponsor-2017/trustyou-logo.png" alt="TrustYou GmbH">
       </a>
-    </div>
-
-    <div class="col s12 m4">
-      <a href="https://www.codecentric.de/">
+      <a href="https://www.codecentric.de/" class="sponsor">
         <img class="responsive-img" src="img/cc_logo.png">
       </a>
-    </div>
-  </div>
-
-  <div class="row">
-    <div class="col s12 m4">
-      <a href="http://www.mercateo.com/corporate/">
+      <a href="http://www.mercateo.com/corporate/" class="sponsor">
         <img class="responsive-img" src="img/sponsor-2017/mercateo.jpg">
       </a>
-    </div>
-    <div class="col s12 m4">
-      <a href="https://sinnerschrader.com/">
+      <a href="https://sinnerschrader.com/" class="sponsor">
         <img class="responsive-img" src="img/sponsor-2017/sinnerschrader.png">
       </a>
     </div>


### PR DESCRIPTION
This improves the sponsor section layout on the start page, especially on mobile devices.

## Before

On mobile: 

![screenshot_20170521_171842](https://cloud.githubusercontent.com/assets/188915/26285261/93d5058c-3e4c-11e7-8165-de3143919a91.png)

## After

On mobile:

![screenshot_20170521_173845](https://cloud.githubusercontent.com/assets/188915/26285263/a0e3a972-3e4c-11e7-8e51-495bc2230131.png)

On desktop:

![screenshot_20170521_173902](https://cloud.githubusercontent.com/assets/188915/26285265/a456777e-3e4c-11e7-9a98-d69ffcb5bbf1.png)
