### PR TITLE
get rid of google error message

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -43,4 +43,5 @@ function initialize() {
   });
 }
 
-google.maps.event.addDomListener(window, 'load', initialize);
+typeof google != 'undefined' 
+  && google.maps.event.addDomListener(window, 'load', initialize);


### PR DESCRIPTION
 the sponsoring page doesn't have a google map, so initialization failed. This checks for the google object to be available first.