### PR TITLE
Add Jonathan Häberle to participants

### DIFF
--- a/participants/jonathan_haeberle.json
+++ b/participants/jonathan_haeberle.json
@@ -1,0 +1,20 @@
+{
+  "name": "Jonathan Häberle",
+  "company": "Codastic",
+  "email": "jh@codastic.com",
+  "tags": [ "react", "redux", "testing", "es6" ],
+  "when": {
+    "friday": true,
+    "friday_party": true,
+    "saturday": true
+  },
+  "what_is_my_connection_to_javascript": "It's daily business. I'm a full stack developer. I love pure code.",
+  "what_can_i_contribute": "Development experience with react",
+  "tshirt": "M-L",
+  "urls": {
+    "photo": "https://avatars0.githubusercontent.com/u/307704?v=3&s=460",
+    "homepage": "http://www.codastic.com",
+    "github": "https://github.com/dreampulse",
+    "twitter": "https://twitter.com/dreampulse"
+  }
+}


### PR DESCRIPTION
I would like to register for JS CraftCamp.    
- [x] My Pull Request contains a json file `$firstname_$lastname.json` or `$nickname.json`    
- [x] The json file follows the template at https://github.com/jscraftcamp/website/blob/master/participants/_template.json and contains the mandatory fields `name`, `tags`, `when`, `what_is_my_connection_to_javascript` and `what_can_i_contribute`    
- [x] If I can't attend, I will either send another Pull Request removing my json file or an E-Mail with the subject 'UNREGISTER' to team@jscraftcamp.org
