### PR TITLE
add marco emrich to participants

### DIFF
--- a/participants/marco_emrich.json
+++ b/participants/marco_emrich.json
@@ -1,0 +1,21 @@
+{
+  "name" : "Marco Emrich",
+  "company" : "owl.institute",
+  "email": "marcoemrich77@googlemail.com",
+  "tags" : [ "tdd", "clean code", "fp", "ramda", "writing", "teaching", "crazystuff" ],
+  "when" :
+  {
+    "friday" : true,
+    "friday_party": true,
+    "saturday" : true
+  },
+  "what_is_my_connection_to_javascript" : "I'm a JS developer and wrote several (mostly German) JS-Books.",
+  "what_can_i_contribute" : "I can show you functional programming in JS or we explore testing and design concepts in code together",
+  "tshirt" : "M-XL",
+  "urls" : {
+    "photo" : "https://avatars0.githubusercontent.com/u/447570?v=3&s=460",
+    "homepage" : "https://www.amazon.de/Marco-Emrich/e/B00BY3UC8C/",
+    "github" : "https://github.com/marcoemrich",
+    "twitter" : "https://twitter.com/marcoemrich"
+  }
+}


### PR DESCRIPTION
I would like to register for JS CraftCamp.    
- [x] My Pull Request contains a json file `$firstname_$lastname.json` or `$nickname.json`    
- [x] The json file follows the template at https://github.com/jscraftcamp/website/blob/master/participants/_template.json and contains the mandatory fields `name`, `tags`, `when`, `what_is_my_connection_to_javascript` and `what_can_i_contribute`    
- [x] If I can't attend, I will either send another Pull Request removing my json file or an E-Mail with the subject 'UNREGISTER' to team@jscraftcamp.org
