### PR TITLE
add stefan siegl to list of participants

### DIFF
--- a/participants/stesie.json
+++ b/participants/stesie.json
@@ -1,0 +1,21 @@
+{
+  "name": "Stefan Siegl",
+  "company": "Mayflower GmbH",
+  "tags": ["Craftsmanship", "clean code", "elmlang", "react", "redux"],
+  "when": {
+    "friday": true,
+    "friday_party": true,
+    "saturday": true
+  },
+  "email": "stefan.siegl@mayflower.de",
+  "dietary_requirements": "vegan",
+  "what_is_my_connection_to_javascript": "I'm a fullstack developer (yet more in love with backend tasks), have done some React/Redux stuff and fell in love with Elm.  Also I'm maintaining the V8Js extension to PHP for quite a while now :-)",
+  "what_can_i_contribute": "Some Elm knowhow and some V8 internals/embedding knowledge",
+  "tshirt": "M-XL",
+  "urls": {
+    "photo": "https://pbs.twimg.com/profile_images/2182670421/stesie-fink-auf-auge-640px_400x400.jpg",
+    "homepage": "https://stesie.github.io/",
+    "github": "https://github.com/stesie",
+    "twitter": "https://twitter.com/stesie23"
+  }
+}


### PR DESCRIPTION
I would like to register for JS CraftCamp.    
- [x] My Pull Request contains a json file `$firstname_$lastname.json` or `$nickname.json`    
- [x] The json file follows the template at https://github.com/jscraftcamp/website/blob/master/participants/_template.json and contains the mandatory fields `name`, `tags`, `when`, `what_is_my_connection_to_javascript` and `what_can_i_contribute`    
- [x] If I can't attend, I will either send another Pull Request removing my json file or an E-Mail with the subject 'UNREGISTER' to team@jscraftcamp.org
