### PR TITLE
added register json

### DIFF
--- a/participants/simon_kindlein.json
+++ b/participants/simon_kindlein.json
@@ -11,5 +11,6 @@
   "what_can_i_contribute": "Passion for Coding, some experience and a lot of curiosity",
   "tshirt": "M-M",
   "urls": {
+    "github": "https://github.com/Psystor"
    }
 }

--- a/participants/simon_kindlein.json
+++ b/participants/simon_kindlein.json
@@ -1,0 +1,15 @@
+{
+  "name": "Simon Kindlein",
+  "tags": ["node", "clean", "tdd", "architecture", "automation", "new Stuff"],
+  "when": {
+    "friday": true,
+    "friday_party": true,
+    "saturday": true
+  },
+  "email": "simonkindlein@gmx.de",
+  "what_is_my_connection_to_javascript": "Developing JavaScript for two years now. Got to use it for both, front and backend.",
+  "what_can_i_contribute": "Passion for Coding, some experience and a lot of curiosity",
+  "tshirt": "M-M",
+  "urls": {
+   }
+}


### PR DESCRIPTION
I would like to register for JS CraftCamp.    
- [ x] My Pull Request contains a json file `$firstname_$lastname.json` or `$nickname.json`    
- [ x] The json file follows the template at https://github.com/jscraftcamp/website/blob/master/participants/_template.json and contains the mandatory fields `name`, `tags`, `when`, `what_is_my_connection_to_javascript` and `what_can_i_contribute` 

(Btw.: 'what_can_i_contribute' is not marked as madantory on your registration page's docu - you might want to change it ;))
   
- [x ] If I can't attend, I will either send another Pull Request removing my json file or an E-Mail with the subject 'UNREGISTER' to team@jscraftcamp.org
