### PR TITLE
Add Sergii Paryzhskyi to participants

### DIFF
--- a/participants/sergii_paryzhskyi.json
+++ b/participants/sergii_paryzhskyi.json
@@ -1,0 +1,18 @@
+{
+  "name": "Sergii Paryzhskyi",
+  "company": "HolidayCheck",
+  "tags": ["functional programming", "tdd", "software craftsmanship"],
+  "when": {
+    "friday": true,
+    "friday_party": true,
+    "saturday": false
+  },
+  "email": "parizhskiy@gmail.com",
+  "dietary_requirements": "none",
+  "what_is_my_connection_to_javascript": "Using it daily @ work",
+  "what_can_i_contribute": "idk yet",
+  "tshirt": "M-L",
+  "urls": {
+    "github": "https://github.com/HeeL"
+  }
+}


### PR DESCRIPTION
I would like to register for JS CraftCamp.    
- [x] My Pull Request contains a json file `$firstname_$lastname.json` or `$nickname.json`    
- [x] The json file follows the template at https://github.com/jscraftcamp/website/blob/master/participants/_template.json and contains the mandatory fields `name`, `tags`, `when`, `what_is_my_connection_to_javascript` and `what_can_i_contribute`    
- [x] If I can't attend, I will either send another Pull Request removing my json file or an E-Mail with the subject 'UNREGISTER' to team@jscraftcamp.org
