### PR TITLE
Remove -p argument for prebuild task

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "recursive-readdir-sync": "^1.0.6"
   },
   "scripts": {
-    "prebuild": "mkdir -p ./dist",
+    "prebuild": "mkdir ./dist",
     "build": "harp compile ./src ./dist; cp CNAME dist/; npm run 'build:participants.json'",
     "build:participants.json": "node scripts/concat-json.js ./participants dist/participants.json; cp ./dist/participants.json ./src/",
     "start": "harp server ./src & browser-sync start --proxy 'localhost:9000' --files 'src/**/*.ejs, src/**/*.css', src/**/*.js",


### PR DESCRIPTION
There is no need to pass `-p` to `mkdir` because you create just one directory