### PR TITLE
add registration data for Olaf Merkert

### DIFF
--- a/participants/olaf_merkert.json
+++ b/participants/olaf_merkert.json
@@ -1,0 +1,17 @@
+{
+  "name": "Olaf Merkert",
+  "company": "TNG Technology Consulting GmbH",
+  "tags": ["typescript", "react", "redux"],
+  "when": {
+    "friday": true,
+    "friday_party": true,
+    "saturday": true
+  },
+  "what_is_my_connection_to_javascript": "My first contact with JavaScript goes back to my school years, when IE6 was the hot stuff. Nowadays, I am working as a full stack developer with a big focus on the React-Redux frontend written in TypeScript.",
+  "what_can_i_contribute": "Experiences with TypeScript, architecting larger Redux applications, and testing React applications. And how to set up Emacs to work on TypeScript code.",
+  "tshirt": "M-L",
+  "urls": {
+    "homepage": "https://www.sl2z.de/~olaf/",
+    "github": "https://github.com/OlafMerkert"
+  }
+}


### PR DESCRIPTION
I would like to register for JS CraftCamp.    
- [x] My Pull Request contains a json file `$firstname_$lastname.json` or `$nickname.json`    
- [x] The json file follows the template at https://github.com/jscraftcamp/website/blob/master/participants/_template.json and contains the mandatory fields `name`, `tags`, `when`, `what_is_my_connection_to_javascript` and `what_can_i_contribute`    
- [x] If I can't attend, I will either send another Pull Request removing my json file or an E-Mail with the subject 'UNREGISTER' to team@jscraftcamp.org
- [x] I agree that the data I enter in the registration can be used for running the event, e.g. make a name tag, count me as participant. I acknowledge that my data are public on github.
