### PR TITLE
Add Jörn Bernhardt to the list of participants

### DIFF
--- a/participants/joern_bernhardt.json
+++ b/participants/joern_bernhardt.json
@@ -1,0 +1,13 @@
+{
+  "name": "Jörn Bernhardt",
+  "company": "compose.us",
+  "tags": ["react", "vuejs", "testing", "founder"],
+  "when": {
+    "friday": true,
+    "friday_party": true,
+    "saturday": true
+  },
+  "what_is_my_connection_to_javascript": "Built websites, browser games, web apps, kiosk systems and automated workflows with JavaScript. I gave workshops on JavaScript and testing. I once made a selfie with Brendan Eich.",
+  "what_can_i_contribute": "During the last JSCraftCamp, I've tried to get results from sessions into a single repo for the participants to see. Maybe I can set this up once again.",
+  "tshirt": "M-L"
+}


### PR DESCRIPTION
I would like to register for JS CraftCamp.
- [x] My Pull Request contains a json file `$firstname_$lastname.json` or `$nickname.json`
- [x] The json file follows the template at https://github.com/jscraftcamp/website/blob/master/participants/_template.json and contains the mandatory fields `name`, `tags`, `when`, `what_is_my_connection_to_javascript` and `what_can_i_contribute`
- [x] If I can't attend, I will either send another Pull Request removing my json file or an E-Mail with the subject 'UNREGISTER' to team@jscraftcamp.org
- [x] I agree that the data I enter in the registration can be used for running the event, e.g. make a name tag, count me as participant. I acknowledge that my data are public on github.
