### PR TITLE
Add Michael Gerhaeuser to participants

### DIFF
--- a/participants/michael_gerhaeuser.json
+++ b/participants/michael_gerhaeuser.json
@@ -1,0 +1,14 @@
+{
+  "name": "Michael Gerhaeuser",
+  "company": "Method Park",
+  "tags": ["es2019", "typescript", "react", "node", "rust", "webassembly"],
+  "when": {
+    "friday": true,
+    "friday_party": true,
+    "saturday": true
+  },
+  "dietary_requirements": "none",
+  "what_is_my_connection_to_javascript": "js dev for 10+ years",
+  "what_can_i_contribute": "Share my experience with webassembly. Discuss js in general, especially new and upcoming features.",
+  "tshirt": "M-XL"
+}


### PR DESCRIPTION
I would like to register for JS CraftCamp.    
- [x] My Pull Request contains a json file `$firstname_$lastname.json` or `$nickname.json`    
- [x] The json file follows the template at https://github.com/jscraftcamp/website/blob/master/participants/_template.json and contains the mandatory fields `name`, `tags`, `when`, `what_is_my_connection_to_javascript` and `what_can_i_contribute`    
- [x] If I can't attend, I will either send another Pull Request removing my json file or an E-Mail with the subject 'UNREGISTER' to team@jscraftcamp.org
- [x] I agree that the data I enter in the registration can be used for running the event, e.g. make a name tag, count me as participant. I acknowledge that my data are public on github.
