### PR TITLE
adds Tanner Hoisington to participants

### DIFF
--- a/participants/tanner_hoisington.json
+++ b/participants/tanner_hoisington.json
@@ -1,0 +1,13 @@
+{
+    "name": "Tanner Hoisington",
+    "company": "Peerigon GmbH",
+    "when": {
+      "friday": false,
+      "friday_party": false,
+      "saturday": true
+     },
+     "dietary_requirements": "sandwiches without the sauce already on them (they always come with the sauce!)",
+     "what_is_my_connection_to_javascript": "Discovered I loved it towards the end of my time at university in America. Came to Germany to start as a trainee",
+     "tshirt": "M-L"
+  }
+  


### PR DESCRIPTION
I would like to register for JS CraftCamp.    
- [x] My Pull Request contains a json file `$firstname_$lastname.json` or `$nickname.json`    
- [x] The json file follows the template at https://github.com/jscraftcamp/website/blob/master/participants/_template.json and contains the mandatory fields `name`, `when`, `what_is_my_connection_to_javascript` and `what_can_i_contribute`    
- [x] If I can't attend, I will either send another Pull Request removing my json file or an E-Mail with the subject 'UNREGISTER' to team@jscraftcamp.org
- [x] I agree that the data I enter in the registration can be used for running the event, e.g. make a name tag, count me as participant. I acknowledge that my data are public on github.
