### PR TITLE
Create matthias_jahn.json

### DIFF
--- a/participants/matthias_jahn.json
+++ b/participants/matthias_jahn.json
@@ -1,0 +1,12 @@
+{
+  "name": "Matthias Jahn",
+  "company": "Peerigon",
+  "tags": ["javascript", "node", "react"],
+  "when": {
+    "friday": false,
+    "friday_party": false,
+    "saturday": true
+  },
+  "dietary_requirements": "Vegetarian please",
+  "what_is_my_connection_to_javascript": "Working with JavaScript for years and always happy to do that."
+}


### PR DESCRIPTION
I would like to register for JS CraftCamp.    
- [x] My Pull Request contains a json file `$firstname_$lastname.json` or `$nickname.json`    
- [x] The json file follows the template at https://github.com/jscraftcamp/website/blob/master/participants/_template.json and contains the mandatory fields `name`, `when`, `what_is_my_connection_to_javascript` and `what_can_i_contribute`    
- [x] If I can't attend, I will either send another Pull Request removing my json file or an E-Mail with the subject 'UNREGISTER' to team@jscraftcamp.org
- [x] I agree that the data I enter in the registration can be used for running the event, e.g. make a name tag, count me as participant. I acknowledge that my data are public on github.
