### PR TITLE
participants: fix philipp_renoth.json is coming

### DIFF
--- a/participants/philipp_renoth.json
+++ b/participants/philipp_renoth.json
@@ -1,0 +1,13 @@
+{
+  "name": "Philipp Renoth",
+  "company": "ConSol Consulting & Solutions Software GmbH",
+  "when": {
+    "friday": true,
+    "friday_party": true,
+    "saturday": true
+  },
+  "dietary_requirements": "vegetarian",
+  "what_is_my_connection_to_javascript": "Solving everything with JS Frontends or NodeJS Backends, day and night, 24/7, even on public holidays.",
+  "what_can_i_contribute": "React, NodeJS, N-API and C++",
+  "tshirt": "M-XL"
+}


### PR DESCRIPTION
I would like to register for JS CraftCamp.    
- [X] My Pull Request contains a json file `$firstname_$lastname.json` or `$nickname.json`    
- [X] The json file follows the template at https://github.com/jscraftcamp/website/blob/master/participants/_template.json and contains the mandatory fields `name`, `when`, `what_is_my_connection_to_javascript` and `what_can_i_contribute`    
- [X] If I can't attend, I will either send another Pull Request removing my json file or an E-Mail with the subject 'UNREGISTER' to team@jscraftcamp.org
- [X] I agree that the data I enter in the registration can be used for running the event, e.g. make a name tag, count me as participant. I acknowledge that my data are public on github.
