### PR TITLE
No automatic browser start on `npm start`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,26 @@
-## JS Craft Camp
+# JS CraftCamp - Website
 
 This project contains the http://jscraftcamp.org site.
 
-# Development
+## Development
 
-## Prerequisite
+### Prerequisite
 
 The node version required is the one noted in [./.travis.yml].
 How to get the environment up and running, see the section [#local-development-environment-setup] below.
 
-## Local development environment setup
+### Local development environment setup
 
 We offer at least two ways to install this project, you choose the one you like:
 - use you own [global nodejs version](#global-nodejs-version) if installed on your system, or
 - setup everything from scratch [using nix](#setup-via-nix)
 
-### Global nodejs version
+#### Global nodejs version
 
 If you have a global nodejs version (at least the version as noted in the [#prerequisite])
 You don't have to do anythin
 
-### Setup via nix
+#### Setup via nix
 
 If you don't want to rely on a global nodejs version, but want a reproducible environment,
 you can use [nix] as described here.

--- a/README.md
+++ b/README.md
@@ -4,26 +4,27 @@ This project contains the http://jscraftcamp.org site.
 
 ## Development
 
-### Prerequisite
+Getting started to develop on the website follow those steps
 
-The node version required is the one noted in [./.travis.yml].
-How to get the environment up and running, see the section [#local-development-environment-setup] below.
+- set up your development environment, [see below](#development-setup)
+- run `npm i` to install all dependencies
+- run `npm start` which will run the local webserver at [localhost:9000](http://localhost:9000), for developing
+- run `npm test`  to run the tests
+- run `npm run build` to generate all static files and to concatenate all participants files into the `dist` directory (in production this will be done by travis)
 
-### Local development environment setup
+### Development setup
 
-We offer at least two ways to install this project, you choose the one you like:
+We offer two ways to install this project, you choose the one you like:
 - use you own [global nodejs version](#global-nodejs-version) if installed on your system, or
 - setup everything from scratch [using nix](#setup-via-nix)
 
 #### Global nodejs version
 
-If you have a global nodejs version (at least the version as noted in the [#prerequisite])
-You don't have to do anythin
+If you want to use your (global) nodejs setup, find out which version we require in the [./.travis.yml].
 
 #### Setup via nix
 
-If you don't want to rely on a global nodejs version, but want a reproducible environment,
-you can use [nix] as described here.
+If you don't want to rely on a global nodejs version, but want a reproducible environment, you can use [nix] as described here.
 
 1) Make sure to have nix installed (see [nixos.org/nix][nix]) and then
 1) `cd <project-dir>`
@@ -33,13 +34,5 @@ you can use [nix] as described here.
 1) now you have a shell with a deterministic environment (incl. the right nodejs version)
 
 [nix]: http://nixos.org/nix/
-
-
-## How to develop?
-
-- run `npm i` to install all dependencies
-- run `npm start` which will run the local webserver, for developing
-- run `npm test`  to run the tests
-- run `npm run build` to generate all static files and to concatenate all participants files into the `dist` directory
 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JS CraftCamp - Website
 
-This project contains the http://jscraftcamp.org site.
+This project contains the [jscraftcamp.org](http://jscraftcamp.org) website and all the setup for the deployment.
 
 ## Development
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "node": ">= 6.6.0"
   },
   "devDependencies": {
-    "browser-sync": "^2.24.4",
     "hamjest": "^3.2.0",
     "harp": "^0.25.0",
     "hashcode": "^1.0.3",
@@ -18,7 +17,7 @@
     "prebuild": "mkdir ./dist",
     "build": "harp compile ./src ./dist; cp CNAME dist/; npm run 'build:participants.json'",
     "build:participants.json": "node scripts/concat-json.js ./participants dist/participants.json; cp ./dist/participants.json ./src/",
-    "start": "harp server ./src & browser-sync start --proxy 'localhost:9000' --files 'src/**/*.ejs, src/**/*.css', src/**/*.js",
+    "start": "harp server ./src",
     "test": "mocha test"
   },
   "author": "David Losert <david.losert@virtual-identity.com>",


### PR DESCRIPTION
- when developing let me (developer) control which browser to use and restarting it, not the `npm start` script
- improve README a bit