### PR TITLE
add participant

### DIFF
--- a/participants/frank_mueller.json
+++ b/participants/frank_mueller.json
@@ -1,0 +1,18 @@
+{
+  "name": "Frank Müller",
+  "company": "SC-Networks GmbH",
+  "when": {
+    "friday": true,
+    "friday_party": false,
+    "saturday": true
+  },
+  "tags": [
+    "architecture",
+    "project-structure",
+    "typescript"
+  ],
+  "dietary_requirements": "",
+  "what_is_my_connection_to_javascript": "I started learning javascript 1.5 years ago and work as a Junior in my company.",
+  "what_can_i_contribute": "As I am on a junior level, I dont feel like I can contribute a talk. But I like to participate in any discussion about frontend development.",
+  "tshirt": "M-L"
+}


### PR DESCRIPTION
I would like to register for JS CraftCamp.    
- [x] My Pull Request contains a json file `$firstname_$lastname.json` or `$nickname.json`    
- [x] The json file follows the template at https://github.com/jscraftcamp/website/blob/master/participants/_template.json and contains the mandatory fields `name`, `when`, `what_is_my_connection_to_javascript` and `what_can_i_contribute`    
- [x] If I can't attend, I will either send another Pull Request removing my json file or an E-Mail with the subject 'UNREGISTER' to team@jscraftcamp.org
- [x] I agree that the data I enter in the registration can be used for running the event, e.g. make a name tag, count me as participant. I acknowledge that my data are public on github.
