### PR TITLE
Modify participation dates and Add a tag

### DIFF
--- a/participants/alessandro_vizin.json
+++ b/participants/alessandro_vizin.json
@@ -2,10 +2,13 @@
   "name": "Alessandro Vizin",
   "company": "Valtech",
   "when": {
-    "friday": false,
-    "friday_party": false,
+    "friday": true,
+    "friday_party": true,
     "saturday": true
   },
+  "tags": [
+    "VueJS"
+  ],
   "what_is_my_connection_to_javascript": "I have been frontend developer for 3 years but I intensively work with JS since last year. In the last months we discovered a fantastic framework called VueJS, but I would like to improve my comprehension of other patterns to develop more solid code.",
   "what_can_i_contribute": "Maybe in sharing my experience as part of an agile team.",
   "tshirt": "M-M"


### PR DESCRIPTION
I would like to register for JS CraftCamp.    
- [x] My Pull Request contains a json file `$firstname_$lastname.json` or `$nickname.json`    
- [x] The json file follows the template at https://github.com/jscraftcamp/website/blob/master/participants/_template.json and contains the mandatory fields `name`, `when`, `what_is_my_connection_to_javascript` and `what_can_i_contribute`    
- [x] If I can't attend, I will either send another Pull Request removing my json file or an E-Mail with the subject 'UNREGISTER' to team@jscraftcamp.org
- [x] I agree that the data I enter in the registration can be used for running the event, e.g. make a name tag, count me as participant. I acknowledge that my data are public on github.
