### PR TITLE
Create robert_kalscheuer.json

### DIFF
--- a/participants/robert_kalscheuer.json
+++ b/participants/robert_kalscheuer.json
@@ -1,0 +1,16 @@
+{
+  "name": "Robert Kalscheuer",
+  "company": "sqmok",
+  "tags": ["Ember", "TDD", "Software Crafting", "DevOps"],
+  "when": {
+    "friday": true,
+    "friday_party": true,
+    "saturday": true
+  },
+  "email": "",
+  "dietary_requirements": "nothing special",
+  "what_is_my_connection_to_javascript": "using and loving js",
+  "what_can_i_contribute": "experience and enthusiasm; Critical thinking",
+  "tshirt": "M-L",
+  "urls": {}
+}


### PR DESCRIPTION
I would like to register for JS CraftCamp.    
- [X ] My Pull Request contains a json file `$firstname_$lastname.json` or `$nickname.json`    
- [X ] The json file follows the template at https://github.com/jscraftcamp/website/blob/master/participants/_template.json and contains the mandatory fields `name`, `when`, `what_is_my_connection_to_javascript` and `what_can_i_contribute`    
- [X ] If I can't attend, I will either send another Pull Request removing my json file or an E-Mail with the subject 'UNREGISTER' to team@jscraftcamp.org
- [X ] I agree that the data I enter in the registration can be used for running the event, e.g. make a name tag, count me as participant. I acknowledge that my data are public on github.
