### PR TITLE
Added personal file for the participation in JS Camp 2018

### DIFF
--- a/participants/petar_milutinovic.json
+++ b/participants/petar_milutinovic.json
@@ -1,0 +1,13 @@
+{
+  "name": "Petar Milutinovic",
+  "company": "Netcentric",
+  "when": {
+    "friday": true,
+    "friday_party": true,
+    "saturday": true
+  },
+  "dietary_requirements": "",
+  "what_is_my_connection_to_javascript": "Working with javascript fulltime for more than 8 years now, and have love / hate weird relationship with it. Worked with most of the frameworks / libraries etc out there (even dojo long time ago, god forbid), rode hype trains multiple times, now settled down on being basic (ES6 and up) and getting stuff done without getting focused on CV development. Simple code, simple solutions, easy to read is my moto.",
+  "what_can_i_contribute": "I'm here for the free beer. And maybe talk about code, architecture, design, user experience, and scary topics like management and business",
+  "tshirt": "M-S"
+}


### PR DESCRIPTION
I would like to register for JS CraftCamp.    
- [x] My Pull Request contains a json file `$firstname_$lastname.json` or `$nickname.json`    
- [x] The json file follows the template at https://github.com/jscraftcamp/website/blob/master/participants/_template.json and contains the mandatory fields `name`, `when`, `what_is_my_connection_to_javascript` and `what_can_i_contribute`    
- [x] If I can't attend, I will either send another Pull Request removing my json file or an E-Mail with the subject 'UNREGISTER' to team@jscraftcamp.org
- [x] I agree that the data I enter in the registration can be used for running the event, e.g. make a name tag, count me as participant. I acknowledge that my data are public on github.
