### PR TITLE
added julian_jaser.json for registration

### DIFF
--- a/participants/julian_jaser.json
+++ b/participants/julian_jaser.json
@@ -1,0 +1,14 @@
+{
+    "name": "Julian Jaser",
+    "when": {
+      "friday": false,
+      "friday_party": true,
+      "saturday": true
+    },
+    "tags": ["Javascript", "IoT", "Node.js"],
+    "dietary_requirements": "",
+    "what_is_my_connection_to_javascript": "I am hobby developer and I am mostly writing small applications with node.js backend to make my life easier.",
+    "what_can_i_contribute": "I do not know yet, what a javascript-loving chemist can contribute but maybe I have another point of view on some things.",
+    "tshirt": "M-M"
+  }
+  


### PR DESCRIPTION
I would like to register for JS CraftCamp.    
- [x] My Pull Request contains a json file `$firstname_$lastname.json` or `$nickname.json`    
- [x] The json file follows the template at https://github.com/jscraftcamp/website/blob/master/participants/_template.json and contains the mandatory fields `name`, `when`, `what_is_my_connection_to_javascript` and `what_can_i_contribute`    
- [x] If I can't attend, I will either send another Pull Request removing my json file or an E-Mail with the subject 'UNREGISTER' to team@jscraftcamp.org
- [x] I agree that the data I enter in the registration can be used for running the event, e.g. make a name tag, count me as participant. I acknowledge that my data are public on github.
