### PR TITLE
add participant vannsl

### DIFF
--- a/participants/vannsl.json
+++ b/participants/vannsl.json
@@ -1,0 +1,15 @@
+{
+  "name": "Vanessa Böhner",
+  "company": "vannsl.io",
+  "tags": [
+    "Vue"
+  ],
+  "when": {
+    "friday": true,
+    "friday_party": false,
+    "saturday": false
+  },
+  "what_is_my_connection_to_javascript": "I've been a frontend/web/fullstack/whatever developer for about 4 years - currently focused on working with Vue",
+  "what_can_i_contribute": "Working with Vue.js (vue, vue-cli, vuex, jest, vue-test-utils, webpack)",
+  "tshirt": "W-S"
+}


### PR DESCRIPTION
I would like to register for JS CraftCamp.    
- [x] My Pull Request contains a json file `$firstname_$lastname.json` or `$nickname.json`    
- [x] The json file follows the template at https://github.com/jscraftcamp/website/blob/master/participants/_template.json and contains the mandatory fields `name`, `when`, `what_is_my_connection_to_javascript` and `what_can_i_contribute`    
- [x] If I can't attend, I will either send another Pull Request removing my json file or an E-Mail with the subject 'UNREGISTER' to team@jscraftcamp.org
- [x] I agree that the data I enter in the registration can be used for running the event, e.g. make a name tag, count me as participant. I acknowledge that my data are public on github.
