### PR TITLE
Fix link to 2018 photos

### DIFF
--- a/src/index.ejs
+++ b/src/index.ejs
@@ -101,7 +101,7 @@
       <h1 class="header center <%= public._data.baseColor %>-text">JSCraftCamp 2019</h1>
       <h3 class="header center">Will return to Munich in July 19-20!</h3>
       <h3 class="header center light">A BarCamp about JavaScript and Crafting Software</h3>
-      <h3 class="header center light"><a href="/photos2017">Impressions from 2018</a></h3>
+      <h3 class="header center light"><a href="/photos2018">Impressions from 2018</a></h3>
     </div>
   </div>
 </div>


### PR DESCRIPTION
The impression link still links to photos from 2017 but we have photos from 2018 already...!