### PR TITLE
added participant floatec

### DIFF
--- a/participants/floatec.json
+++ b/participants/floatec.json
@@ -1,0 +1,16 @@
+{
+  "name": "Patrick Mueller",
+  "company": "Smokeless",
+  "when": {
+    "friday": true,
+    "friday_party": true,
+    "saturday": true
+  },
+  "tags": ["TypeScript", "React Native", "React","Firebase"],
+  "vegan": false,
+  "vegetarian": false,
+  "allergies": "",
+  "what_is_my_connection_to_javascript": "using it day by day in my comapny. From backend to frontend",
+  "what_can_i_contribute": "I can give a session. I will use tthe time until the evnet to come up with a topic ;-)",
+  "tshirt": "M-XL"
+}


### PR DESCRIPTION
I would like to register for JS CraftCamp.    
- [x] My pull request contains a JSON file `$firstname_$lastname.json` or `$nickname.json`    
- [x] The JSON file follows the template at https://github.com/jscraftcamp/website/blob/master/participants/_template.json and contains the mandatory fields `name`, `when`, `what_is_my_connection_to_javascript` and `what_can_i_contribute`    
- [x] If I can't attend, I will either send another pull request removing my JSON file or an e-mail with the subject 'UNREGISTER' to team@jscraftcamp.org
- [x] I agree that the data I enter in the registration can be used for running the event, e.g. make a name tag, count me as participant. I acknowledge that my data are public on github.
- [x] I agree that photos and videos might be taken and published (e.g. on social media) during the event.

Are you from a sponsoring company?
- [ ] Yes, I am from company ?????
