### PR TITLE
Make `tags` in participants.json required

### DIFF
--- a/participants/paul_janicki.json
+++ b/participants/paul_janicki.json
@@ -6,6 +6,7 @@
     "friday_party": true,
     "saturday": true
   },
+  "tags": ["..."],
   "vegan": false,
   "vegetarian": false,
   "what_is_my_connection_to_javascript": "It's my language of choice for client and server side of web projects and I enjoy working with it. I use Angular and Node.js, I really enjoy Vanilla JS.",

--- a/src/registration.ejs
+++ b/src/registration.ejs
@@ -51,7 +51,7 @@
       <tr><td><code>when.friday</code>*</td>	<td>If you are attending on Friday (Boolean value)</td></tr>
       <tr><td><code>when.friday_party</code>*</td>	<td>If you want to join us on the free Party that will happen Friday after the event (same location). Drinks and food sponsored!</td></tr>
       <tr><td><code>when.saturday</code>*</td><td>If you are attending on Saturday (Boolean value)</td></tr>
-      <tr><td><code>tags</code></td><td>Share what you think is important, use any number of tags. (Array of strings)</td></tr>
+      <tr><td><code>tags</code>*</td><td>Share what you think is important, use at least one tag. (Array of strings)</td></tr>
       <tr><td><code>vegan</code>*</td><td>Let us know if you are a vegan** (Boolean value)</td></tr>
       <tr><td><code>vegetarian</code>*</td><td>Let us know if you are a vegetarian** (Boolean value)</td></tr>
       <tr><td><code>allergies</code></td><td>Tell us if you have any special dietary requirements**</td></tr>

--- a/test/participants.js
+++ b/test/participants.js
@@ -1,7 +1,7 @@
 var assert = require("assert");
 var fs = require("fs");
 var path = require("path");
-var recursiveReaddirSync = require('recursive-readdir-sync')
+var recursiveReaddirSync = require('recursive-readdir-sync');
 
 describe("Participants JSON file", () => {
   var srcdir = "./participants";

--- a/test/participants.js
+++ b/test/participants.js
@@ -61,6 +61,12 @@ describe("Participants JSON file", () => {
         }
       });
 
+      it('must contain tags', () => {
+        assert.ok('tags' in object);
+        assert.ok(Array.isArray(object.tags));
+        assert.ok(object.tags.length > 0);
+      });
+
       it("may contain `allergies`", () => {
           if(typeof object.allergies !== "undefined") {
               assert.equal(typeof object.allergies, "string", "'allergies' must be a string");


### PR DESCRIPTION
- [x] make the tests fail when not at least one tag is given
- [x] describe it on the registration page
- [x] fix the one participant's JSON file to contain one tag