### PR TITLE
Add christopher_brinker.json as participant

### DIFF
--- a/participants/christopher_brinker.json
+++ b/participants/christopher_brinker.json
@@ -1,0 +1,16 @@
+{
+  "name": "Christopher Brinker",
+  "company": "Hochschule Landshut",
+  "when": {
+    "friday": true,
+    "friday_party": true,
+    "saturday": true
+  },
+  "tags": ["React", "Python"],
+  "vegan": false,
+  "vegetarian": false,
+  "allergies": "None",
+  "what_is_my_connection_to_javascript": "Tripped over JS first when I we decided to use React for our frontend during a seminar in my studies. Had fun with it, now I just want to improve.",
+  "what_can_i_contribute": "Good mood and bad jokes!",
+  "tshirt": "M-L"
+}


### PR DESCRIPTION
I would like to register for JS CraftCamp.    
- [X] My pull request contains a JSON file `$firstname_$lastname.json` or `$nickname.json`    
- [X] The JSON file follows the template at https://github.com/jscraftcamp/website/blob/master/participants/_template.json and contains the mandatory fields `name`, `when`, `what_is_my_connection_to_javascript` and `what_can_i_contribute`    
- [X] If I can't attend, I will either send another pull request removing my JSON file or an e-mail with the subject 'UNREGISTER' to team@jscraftcamp.org
- [X] I agree that the data I enter in the registration can be used for running the event, e.g. make a name tag, count me as participant. I acknowledge that my data are public on github.
- [X] I agree that photos and videos might be taken and published (e.g. on social media) during the event.

Are you from a sponsoring company?
- [ ] Yes, I am from company ?????
