### PR TITLE
Create johannes_ewald.json

### DIFF
--- a/participants/johannes_ewald.json
+++ b/participants/johannes_ewald.json
@@ -1,0 +1,15 @@
+{
+  "name": "Johannes Ewald",
+  "company": "Peerigon GmbH",
+  "when": {
+    "friday": true,
+    "friday_party": true,
+    "saturday": true
+  },
+  "tags": ["javascript", "webpack", "typescript", "react", "vue"],
+  "vegan": false,
+  "vegetarian": true,
+  "what_is_my_connection_to_javascript": "I write it, I teach it, I love it!",
+  "what_can_i_contribute": "Give webpack config support, yay! :)",
+  "twitter": "jhnnns"
+}


### PR DESCRIPTION
I would like to register for JS CraftCamp.    
- [x] My pull request contains a JSON file `$firstname_$lastname.json` or `$nickname.json`    
- [x] The JSON file follows the template at https://github.com/jscraftcamp/website/blob/master/participants/_template.json and contains the mandatory fields `name`, `when`, `what_is_my_connection_to_javascript` and `what_can_i_contribute`    
- [x] If I can't attend, I will either send another pull request removing my JSON file or an e-mail with the subject 'UNREGISTER' to team@jscraftcamp.org
- [x] I agree that the data I enter in the registration can be used for running the event, e.g. make a name tag, count me as participant. I acknowledge that my data are public on github.
- [x] I agree that photos and videos might be taken and published (e.g. on social media) during the event.

Are you from a sponsoring company?
- [x] Yes, I am from company Peerigon GmbH
