### PR TITLE
Participant template `twitter` field

### DIFF
--- a/participants/_template.json
+++ b/participants/_template.json
@@ -12,5 +12,6 @@
   "allergies": "",
   "what_is_my_connection_to_javascript": "...",
   "what_can_i_contribute": "???",
-  "tshirt": "/^(W|M)-(S|M|L|XL)$/"  
+  "tshirt": "/^(W|M)-(S|M|L|XL)$/",
+  "twitter": ""
 }


### PR DESCRIPTION
This adds the twitter field. I'd prefer `null` as default value, but went with the empty string `""` for consistency reasons.

Fixes #696

