### PR TITLE
Add manuel_ernst.json

### DIFF
--- a/participants/manuel_ernst.json
+++ b/participants/manuel_ernst.json
@@ -1,0 +1,24 @@
+{
+  "name": "Manuel E.",
+  "company": "Method Park",
+  "when": {
+    "friday": true,
+    "friday_party": true,
+    "saturday": true
+  },
+  "tags": [
+    "ES2019",
+    "Node.js",
+    "Typescript",
+    "React",
+    "React Native",
+    "Testing"
+  ],
+  "vegan": false,
+  "vegetarian": true,
+  "allergies": "",
+  "what_is_my_connection_to_javascript": "Web development for >15y, focused on backend development with Node.js but also interested in all kinds of frontend frameworks",
+  "what_can_i_contribute": "frontend testing in React, backend development with Node.js",
+  "tshirt": "M-M",
+  "twitter": "seriousManual"
+}


### PR DESCRIPTION
I would like to register for JS CraftCamp.    
- [X] My pull request contains a JSON file `$firstname_$lastname.json` or `$nickname.json`    
- [X] The JSON file follows the template at https://github.com/jscraftcamp/website/blob/master/participants/_template.json and contains the mandatory fields `name`, `when`, `what_is_my_connection_to_javascript` and `what_can_i_contribute`    
- [X] If I can't attend, I will either send another pull request removing my JSON file or an e-mail with the subject 'UNREGISTER' to team@jscraftcamp.org
- [X] I agree that the data I enter in the registration can be used for running the event, e.g. make a name tag, count me as participant. I acknowledge that my data are public on github.
- [X] I agree that photos and videos might be taken and published (e.g. on social media) during the event.

Are you from a sponsoring company?
- [ ] Yes, I am from company ?????
