### PR TITLE
Add Carsten to participants

### DIFF
--- a/participants/carsten_lamm.json
+++ b/participants/carsten_lamm.json
@@ -1,0 +1,17 @@
+{
+  "name": "Carsten Lamm",
+  "company": "kontextR GmbH",
+  "when": {
+    "friday": true,
+    "friday_party": true,
+    "saturday": false
+  },
+  "tags": ["respectful", "TDD", "chrome extensions"],
+  "vegan": false,
+  "vegetarian": false,
+  "allergies": "soy, nuts, carrots",
+  "what_is_my_connection_to_javascript": "I do javascript for 10 years.",
+  "what_can_i_contribute": "ideas, critical thoughts, tdd",
+  "tshirt": "M-M",
+  "twitter": "FQ400"
+}


### PR DESCRIPTION
I would like to register for JS CraftCamp.    
- [x] My pull request contains a JSON file `$firstname_$lastname.json` or `$nickname.json`    
- [x] The JSON file follows the template at https://github.com/jscraftcamp/website/blob/master/participants/_template.json and contains the mandatory fields `name`, `when`, `what_is_my_connection_to_javascript` and `what_can_i_contribute`    
- [x] If I can't attend, I will either send another pull request removing my JSON file or an e-mail with the subject 'UNREGISTER' to team@jscraftcamp.org
- [x] I agree that the data I enter in the registration can be used for running the event, e.g. make a name tag, count me as participant. I acknowledge that my data are public on github.
- [x] I agree that photos and videos might be taken and published (e.g. on social media) during the event.
- [x] I understand that I might NOT get a T-Shirt, because they might be in production already

Are you from a sponsoring company?
- [ ] Yes, I am from company ?????
