### PR TITLE
Add Markus Knittig as participants

### DIFF
--- a/participants/markus_knittig.json
+++ b/participants/markus_knittig.json
@@ -1,0 +1,17 @@
+{
+  "name": "Markus Knittig",
+  "company": "BRYTER",
+  "when": {
+    "friday": true,
+    "friday_party": true,
+    "saturday": true
+  },
+  "tags": ["TypeScript", "Vue", "Kotlin", "CraftBeer"],
+  "vegan": false,
+  "vegetarian": false,
+  "allergies": "",
+  "what_is_my_connection_to_javascript": "Full-stack developer working on a bigger SPA with all whistles and bells",
+  "what_can_i_contribute": "Experience on how to structure a vue.js app. Kotlin know-how and general software design knowledge",
+  "tshirt": "M-L",
+  "twitter": "mknittig"
+}


### PR DESCRIPTION
I would like to register for JS CraftCamp.    
- [X] My pull request contains a JSON file `$firstname_$lastname.json` or `$nickname.json`    
- [X] The JSON file follows the template at https://github.com/jscraftcamp/website/blob/master/participants/_template.json and contains the mandatory fields `name`, `when`, `what_is_my_connection_to_javascript` and `what_can_i_contribute`    
- [X] If I can't attend, I will either send another pull request removing my JSON file or an e-mail with the subject 'UNREGISTER' to team@jscraftcamp.org
- [X] I agree that the data I enter in the registration can be used for running the event, e.g. make a name tag, count me as participant. I acknowledge that my data are public on github.
- [X] I agree that photos and videos might be taken and published (e.g. on social media) during the event.
- [X] I understand that I might NOT get a T-Shirt, because they might be in production already

Are you from a sponsoring company?
- [ ] Yes, I am from company ?????
