### PR TITLE
Prefer "Angular" name over "AngularJS"

### DIFF
--- a/src/index.ejs
+++ b/src/index.ejs
@@ -136,7 +136,7 @@
     <div class="col s12 m6">
       <h5 class="header center">JavaScript</h5>
       <p class="block">The focus of this BarCamp are JavaScript and related technologies. Possible topics are:
-        Popular frameworks like AngularJS and React, the latest ECMAScript standard, languages like Elm or
+        Popular frameworks like Angular and React, the latest ECMAScript standard, languages like Elm or
         TypeScript which transpile to JavaScript, server-side programming with node.js, paradigms like event
         driven programming or future technologies like WebAssembly.</p>
     </div>


### PR DESCRIPTION
It makes sense to have the new name "Angular" on the website, since "AngularJS" is the older, deprecated version 1.x

https://angular.io vs https://angularjs.org