### PR TITLE
Build storybook on netlify preview

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,9 @@
+# https://docs.netlify.com/configure-builds/file-based-configuration/#post-processing
+
+# default for all branches, overriding the UI setting on netlify.com
+[build]
+  command = "npm run build-storybook -o static/storybook ; npm run build"
+
 # Specific branch context: all deploys from this specific branch will inherit
 # these settings.
 [context."gh-pages"] # 'gh-pages' is a branch name

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,8 +1,8 @@
-# https://docs.netlify.com/configure-builds/file-based-configuration/#post-processing
+# https://docs.netlify.com/configure-builds/file-based-configuration/
 
 # default for all branches, overriding the UI setting on netlify.com
 [build]
-  command = "npm run build-storybook -o static/storybook ; npm run build"
+  command = "npm run build-storybook -- -o static/storybook ; npm run build"
 
 # Specific branch context: all deploys from this specific branch will inherit
 # these settings.

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+# Specific branch context: all deploys from this specific branch will inherit
+# these settings.
+[context."gh-pages"] # 'gh-pages' is a branch name
+  ignore = "true"


### PR DESCRIPTION
## description

Changed the configuration for netlify:

* ignore the gh-pages branch
* run the build-storybook script and include it in Gatsby (just as static resources)

more details/documentation: https://docs.netlify.com/configure-builds/file-based-configuration/

Part of #861 

The resulting page should be available at 🎈 
https://deploy-preview-872--jscraftcamp.netlify.com/storybook

=> So you just need to add the `/storybook` path to the preview-url 🎉 