### PR TITLE
replace 2020 with 2021

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,7 +1,7 @@
 module.exports = {
   siteMetadata: {
-    title: "JSCraftCamp - 2020 in Munich",
-    description: "Website for JSCraftCamp - 2020 in Munich",
+    title: "JSCraftCamp - 2021 in Munich",
+    description: "Website for JSCraftCamp - 2021 in Munich",
     author: "@davelosert, @rhosts, @michaelzoidl, @Narigo",
   },
   pathPrefix: "/",
@@ -43,7 +43,7 @@ module.exports = {
     {
       resolve: "gatsby-plugin-manifest",
       options: {
-        name: "JSCraftCamp - 2020 in Munich",
+        name: "JSCraftCamp - 2021 in Munich",
         short_name: "JSCraftCamp",
         start_url: "/",
         background_color: "#ececec",

--- a/src/components/intro/intro.js
+++ b/src/components/intro/intro.js
@@ -16,7 +16,7 @@ const Intro = () => (
     <div className={style.headline}>
       <Typography component="p" variant="subline">
         Unfortunately and due to the current situation, we can not say if or how
-        JSCC 2020 will actually take place.
+        JSCC 2021 will actually take place.
       </Typography>
       <Typography component="p" variant="subline">
         We from the Orga team are observing the situation and will try to make a
@@ -33,7 +33,7 @@ const Intro = () => (
     </div>
     <div className={style.text}>
       <Typography className={style.headline} component="h1">
-        JSCraftCamp 2020
+        JSCraftCamp 2021
       </Typography>
       { false && // disabled until consideration or current situation
       <Typography variant="subline">


### PR DESCRIPTION
After one year of covid pandemia we need to try a new start, and at least update the year on our web page.