### PR TITLE
remove redundant headline

### DIFF
--- a/src/components/intro/intro.js
+++ b/src/components/intro/intro.js
@@ -20,14 +20,10 @@ const Intro = () => (
     </div>
     <div className={style.headline}>
       <Typography component="p" variant="subline">
-        Save the Date: 17th+18th June 2022
+        Save the Date: June, 17th & 18th 2022
       </Typography>
     </div>
     <div className={style.headline}>
-      <Typography component="p" variant="subline">
-        The Orga team has kicked off the effort for the next steps to bring this
-        years event into fruition
-      </Typography>
       <Typography component="p" variant="subline">
         Stay tuned by following{" "}
         <a href="https://twitter.com/jscraftcamp">@JSCraftCamp on Twitter!</a>


### PR DESCRIPTION
Cleanup: I guess we can remove redundant, obsolete text:

~The Orga team has kicked off the effort for the next steps to bring this years event into fruition~