### PR TITLE
Create patrick_mueller.json

### DIFF
--- a/participants/patrick_mueller.json
+++ b/participants/patrick_mueller.json
@@ -1,0 +1,16 @@
+{
+  "name": "Patrick Müller",
+  "company": "Smokeless",
+  "when": {
+    "friday": true,
+    "saturday": true
+  },
+  "tags": ["Type Script", "React", "React Native","nest.js", "GraphQL"],
+  "vegan": false,
+  "vegetarian": false,
+  "allergies": "",
+  "what_is_my_connection_to_javascript": "using it every day",
+  "what_can_i_contribute": "will deffinatlly give a talk",
+  "tshirt": "M-XL",
+  "twitter": "patrickwirede"
+}


### PR DESCRIPTION
I would like to register for JS CraftCamp.    
- [x] My pull request contains a JSON file `$name_or_nickname.json`    
- [x] The JSON file follows the template at [https://github.com/jscraftcamp/website/blob/master/participants/_template.json](https://jscraftcamp.org/register/) and contains the mandatory fields `name`, `when`, `what_is_my_connection_to_javascript` and `what_can_i_contribute`    
- [x] If I can NOT attend, I will either send another pull request removing my JSON file or an e-mail with the subject 'UNREGISTER' to team@jscraftcamp.org
- [x] I agree that the data I enter in the registration can be used for running the event, e.g. make a name tag, count me as participant. I acknowledge that my data are public on GitHub and I agree that I will be listed on the JSCraftCamp website as a participant.
- [x] I agree that photos and videos might be taken and published (e.g. on social media) during the event.
- [x] I understand that I might NOT get a T-Shirt, because they might be in production already

Are you from a sponsoring company?
- [ ] Yes, I am from company ?????
