### PR TITLE
fix: Use main as default branch name

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 I would like to register for JS CraftCamp.    
 - [ ] My pull request contains a JSON file `$name_or_nickname.json`    
-- [ ] The JSON file follows the template at [https://github.com/jscraftcamp/website/blob/master/participants/_template.json](https://jscraftcamp.org/register/) and contains the mandatory fields `name`, `when`, `what_is_my_connection_to_javascript` and `what_can_i_contribute`    
+- [ ] The JSON file follows the template at [https://github.com/jscraftcamp/website/blob/main/participants/_template.json](https://jscraftcamp.org/register/) and contains the mandatory fields `name`, `when`, `what_is_my_connection_to_javascript` and `what_can_i_contribute`    
 - [ ] If I can NOT attend, I will either send another pull request removing my JSON file or an e-mail with the subject 'UNREGISTER' to team@jscraftcamp.org
 - [ ] I agree that the data I enter in the registration can be used for running the event, e.g. make a name tag, count me as participant. I acknowledge that my data are public on GitHub and I agree that I will be listed on the JSCraftCamp website as a participant.
 - [ ] I agree that photos and videos might be taken and published (e.g. on social media) during the event.

--- a/.github/workflows/registration-tests.yml
+++ b/.github/workflows/registration-tests.yml
@@ -1,7 +1,7 @@
 name: "Check registrations"
 on:
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   test:

--- a/participants/cristobal_heiss.json
+++ b/participants/cristobal_heiss.json
@@ -11,6 +11,6 @@
   "allergies": "none",
   "what_is_my_connection_to_javascript": "In a programming context, I consider JS to be my Native Language. Also I work with it",
   "what_can_i_contribute": "participation in discussions, sharing experiences and point of views",
-  "tshirt": "M",
+  "tshirt": "M-M",
   "twitter": "Cristobalheiss"
 }

--- a/participants/marcoemrich.json
+++ b/participants/marcoemrich.json
@@ -11,6 +11,6 @@
     "vegetarian": false,
     "what_is_my_connection_to_javascript": "I love learning and developing in the JavaScript ecosystem where innovation is always on the speed track",
     "what_can_i_contribute": "I will offer sessions about my main interests depending on demand, like Functional Progamming in JS, Schools of TDD, ...",
-    "tshirt": "M-XXL",
+    "tshirt": "M-XL",
     "twitter": "marcoemrich"
 }

--- a/src/pages/register.js
+++ b/src/pages/register.js
@@ -39,7 +39,7 @@ const Registration = () => (
           <code>npm test</code>
           (more details about this are in the{" "}
           <a
-            href="https://github.com/jscraftcamp/website/blob/master/README.md"
+            href="https://github.com/jscraftcamp/website/blob/main/README.md"
             rel="noreferrer noopener"
             target="_blank"
           >


### PR DESCRIPTION
`master` changed to `main` recently and we should change the instructions and templates accordingly