### PR TITLE
add registration file for msh

### DIFF
--- a/participants/msh.json
+++ b/participants/msh.json
@@ -1,0 +1,16 @@
+{
+  "name": "Maria",
+  "company": "ZDI",
+  "when": {
+    "friday": false,
+    "saturday": true
+  },
+  "tags": ["typescript", "javascript", "backend", "frontend", "serverless", "education", "TDD", "playwright"],
+  "vegan": false,
+  "vegetarian": false,
+  "allergies": "none",
+  "what_is_my_connection_to_javascript": "In my work I'am using TypeScript, sometimes also JavaScript",
+  "what_can_i_contribute": "listening, participating discussions, workshops, sharing experiences",
+  "tshirt": "S",
+  "twitter": "Maria77939067"
+}

--- a/participants/msh.json
+++ b/participants/msh.json
@@ -11,6 +11,6 @@
   "allergies": "none",
   "what_is_my_connection_to_javascript": "In my work I'am using TypeScript, sometimes also JavaScript",
   "what_can_i_contribute": "listening, participating discussions, workshops, sharing experiences",
-  "tshirt": "S",
+  "tshirt": "M-S",
   "twitter": "Maria77939067"
 }


### PR DESCRIPTION
I would like to register for JS CraftCamp.    
- [ x] My pull request contains a JSON file `$name_or_nickname.json`    
- [x ] The JSON file follows the template at [https://github.com/jscraftcamp/website/blob/main/participants/_template.json](https://jscraftcamp.org/register/) and contains the mandatory fields `name`, `when`, `what_is_my_connection_to_javascript` and `what_can_i_contribute`    
- [x ] If I can NOT attend, I will either send another pull request removing my JSON file or an e-mail with the subject 'UNREGISTER' to team@jscraftcamp.org
- [x ] I agree that the data I enter in the registration can be used for running the event, e.g. make a name tag, count me as participant. I acknowledge that my data are public on GitHub and I agree that I will be listed on the JSCraftCamp website as a participant.
- [x] I agree that photos and videos might be taken and published (e.g. on social media) during the event.
- [x ] I understand that I might NOT get a T-Shirt, because they might be in production already
- [ x] I agree to wear my mask to protect everyone as much as possible
- [x ] I will come and have tested and be covid-negative, at least 24h before I join the event

Are you from a sponsoring company?
- [ ] Yes, I am from company ?????
