### PR TITLE
Add Holger to participants

### DIFF
--- a/participants/holgergp.json
+++ b/participants/holgergp.json
@@ -1,0 +1,16 @@
+{
+  "name": "Holger Grosse-Plankermann",
+  "company": "codecentric AG",
+  "when": {
+    "friday": true,
+    "saturday": true
+  },
+  "tags": ["React", "TypeScript", "Redux", "@autoweird.fm", "papperlapapp"],
+  "vegan": false,
+  "vegetarian": false,
+  "allergies": "",
+  "what_is_my_connection_to_javascript": "My first connection to JS was to compile a Mozilla for native SOAP interfaces. It got better since!",
+  "what_can_i_contribute": "I am curious to join your awesome sessions. I can talk about React/Redux, cucumber.js, testing in general, making a podcast and/or a youtube format",
+  "tshirt": "M-M",
+  "twitter": "holgergp"
+}

--- a/participants/holgergp.json
+++ b/participants/holgergp.json
@@ -10,7 +10,7 @@
   "vegetarian": false,
   "allergies": "",
   "what_is_my_connection_to_javascript": "My first connection to JS was to compile a Mozilla for native SOAP interfaces. It got better since!",
-  "what_can_i_contribute": "I am curious to join your awesome sessions. I can talk about React/Redux, cucumber.js, testing in general, making a podcast and/or a youtube format",
+  "what_can_i_contribute": "I am curious to join your awesome sessions. I have opinions about React/Redux, cucumber.js, testing in general. I can share some experiences about making a podcast and/or a youtube format",
   "tshirt": "M-M",
   "twitter": "holgergp"
 }


### PR DESCRIPTION
I would like to register for JS CraftCamp.    
- [X] My pull request contains a JSON file `$name_or_nickname.json`    
- [X ] The JSON file follows the template at [https://github.com/jscraftcamp/website/blob/main/participants/_template.json](https://jscraftcamp.org/register/) and contains the mandatory fields `name`, `when`, `what_is_my_connection_to_javascript` and `what_can_i_contribute`    
- [X] If I can NOT attend, I will either send another pull request removing my JSON file or an e-mail with the subject 'UNREGISTER' to team@jscraftcamp.org
- [X] I agree that the data I enter in the registration can be used for running the event, e.g. make a name tag, count me as participant. I acknowledge that my data are public on GitHub and I agree that I will be listed on the JSCraftCamp website as a participant.
- [X] I agree that photos and videos might be taken and published (e.g. on social media) during the event.
- [X] I understand that I might NOT get a T-Shirt, because they might be in production already
- [X] I agree to wear my mask to protect everyone as much as possible
- [X] I will come and have tested and be covid-negative, at least 24h before I join the event

Are you from a sponsoring company?
- [X] Yes, I am from company codecentric AG
