### PR TITLE
Add missing hygen template files

### DIFF
--- a/_templates/component/new/component.js.ejs.t
+++ b/_templates/component/new/component.js.ejs.t
@@ -1,0 +1,7 @@
+---
+to: src/components/<%= name %>/<%= name %>.js
+---
+import React from 'react';
+import style from './<%= name %>.module.scss';
+
+export default () => <div className={style.root}><%= h.changeCase.pascal(name) %></div>;

--- a/_templates/component/new/component.js.ejs.t
+++ b/_templates/component/new/component.js.ejs.t
@@ -4,4 +4,6 @@ to: src/components/<%= name %>/<%= name %>.js
 import React from 'react';
 import style from './<%= name %>.module.scss';
 
-export default () => <div className={style.root}><%= h.changeCase.pascal(name) %></div>;
+export const <%= h.changeCase.pascal(name) %> = () => <div className={style.root}><%= h.changeCase.pascal(name) %></div>;
+
+export default <%= name %>

--- a/_templates/component/new/component.module.scss.ejs.t
+++ b/_templates/component/new/component.module.scss.ejs.t
@@ -1,0 +1,4 @@
+---
+to: src/components/<%= name %>/<%= name %>.module.scss
+---
+.root {}

--- a/_templates/component/new/component.story.js.ejs.t
+++ b/_templates/component/new/component.story.js.ejs.t
@@ -5,7 +5,7 @@ import React from 'react';
 import <%= h.changeCase.pascal(name) %> from './';
 
 export default {
-  title: '<%= componentKind %>|<%= h.changeCase.pascal(name) %>',
+  title: '<%= componentKind %>/<%= h.changeCase.pascal(name) %>',
   component: <%= h.changeCase.pascal(name) %>
 };
 

--- a/_templates/component/new/component.story.js.ejs.t
+++ b/_templates/component/new/component.story.js.ejs.t
@@ -1,0 +1,12 @@
+---
+to: src/components/<%= name %>/<%= name %>.story.js
+---
+import React from 'react';
+import <%= h.changeCase.pascal(name) %> from './';
+
+export default {
+  title: '<%= componentKind %>|<%= h.changeCase.pascal(name) %>',
+  component: <%= h.changeCase.pascal(name) %>
+};
+
+export const base = () => <<%= h.changeCase.pascal(name) %> />;

--- a/_templates/component/new/index.js.ejs.t
+++ b/_templates/component/new/index.js.ejs.t
@@ -1,0 +1,5 @@
+---
+to: src/components/<%= name %>/index.js
+---
+import <%= h.changeCase.pascal(name) %> from './<%= name %>';
+export default <%= h.changeCase.pascal(name) %>;

--- a/_templates/component/new/prompt.js
+++ b/_templates/component/new/prompt.js
@@ -1,0 +1,8 @@
+module.exports = [
+  {
+    type: 'select',
+    name: 'componentKind',
+    message: 'Select the kind of component you want to create',
+    choices: ['components', 'sections']
+  }
+];


### PR DESCRIPTION
Added missing `hygen` files (still referred to by the readme).

## What is is for?

...making it easier to create `components` in the current design:

Creating a new `Team` **section**:

```
 yarn hygen component new --componentKind sections --name team 
```

Any basic component:

```
 yarn hygen component new --componentKind components --name team 
```

---

Originally created by (kudos goes to)  @michaelzoidl 