### PR TITLE
Register michael for JSCC 2022

### DIFF
--- a/participants/mlgr.json
+++ b/participants/mlgr.json
@@ -1,0 +1,14 @@
+{
+    "name": "Michael Gerhäuser",
+    "company": "Method Park",
+    "when": {
+       "friday": true,
+       "saturday": true
+    },
+    "tags": ["TypeScript", "AspNetCore", "Swagger", "Rust", "Terraform", "NodeJS", "WASM", "Cloud"],
+    "vegan": false,
+    "vegetarian": false,
+    "what_is_my_connection_to_javascript": "None anymore. I only work with TypeScript these days.",
+    "what_can_i_contribute": "Rust; Web apps in production in clouds with Terraform",
+    "tshirt": "M-XXL"
+}


### PR DESCRIPTION
I would like to register for JS CraftCamp.    
- [x] My pull request contains a JSON file `$name_or_nickname.json`    
- [X] The JSON file follows the template at [https://github.com/jscraftcamp/website/blob/main/participants/_template.json](https://jscraftcamp.org/register/) and contains the mandatory fields `name`, `when`, `what_is_my_connection_to_javascript` and `what_can_i_contribute`    
- [X] If I can NOT attend, I will either send another pull request removing my JSON file or an e-mail with the subject 'UNREGISTER' to team@jscraftcamp.org
- [X] I agree that the data I enter in the registration can be used for running the event, e.g. make a name tag, count me as participant. I acknowledge that my data are public on GitHub and I agree that I will be listed on the JSCraftCamp website as a participant.
- [X] I agree that photos and videos might be taken and published (e.g. on social media) during the event.
- [X] I understand that I might NOT get a T-Shirt, because they might be in production already
- [X] I agree to wear my mask to protect everyone as much as possible
- [X] I will come and have tested and be covid-negative, at least 24h before I join the event

Are you from a sponsoring company?
- [X] Yes, I am from company Method Park
