### PR TITLE
Add tsgn to participants

### DIFF
--- a/participants/tsgn.json
+++ b/participants/tsgn.json
@@ -1,0 +1,15 @@
+{
+  "name": "Tobias Gutmann",
+  "company": "Method Park",
+  "when": {
+    "friday": true,
+    "saturday": true
+  },
+  "tags": ["Typescript", "Angular", "RxJS", "NodeJS", "Microservices"],
+  "vegan": false,
+  "vegetarian": false,
+  "what_is_my_connection_to_javascript": "I've been developing applications (Front- and Backend) with JS/TS for the past six years.",
+  "what_can_i_contribute": "I could give a quick introduction to mechanical keebs (❤) and how you can start your very first build.",
+  "tshirt": "M-L",
+  "twitter": "topi_tobster"
+}


### PR DESCRIPTION
I would like to register for JS CraftCamp.    
- [x] My pull request contains a JSON file `$name_or_nickname.json`    
- [x] The JSON file follows the template at [https://github.com/jscraftcamp/website/blob/main/participants/_template.json](https://jscraftcamp.org/register/) and contains the mandatory fields `name`, `when`, `what_is_my_connection_to_javascript` and `what_can_i_contribute`    
- [x] If I can NOT attend, I will either send another pull request removing my JSON file or an e-mail with the subject 'UNREGISTER' to team@jscraftcamp.org
- [x] I agree that the data I enter in the registration can be used for running the event, e.g. make a name tag, count me as participant. I acknowledge that my data are public on GitHub and I agree that I will be listed on the JSCraftCamp website as a participant.
- [x] I agree that photos and videos might be taken and published (e.g. on social media) during the event.
- [x] I understand that I might NOT get a T-Shirt, because they might be in production already
- [x] I agree to wear my mask to protect everyone as much as possible
- [x] I will come and have tested and be covid-negative, at least 24h before I join the event

Are you from a sponsoring company?
- [x] Yes, I am from company Method Park
