### PR TITLE
add participant jeff

### DIFF
--- a/participants/jewgenij_steinhart.json
+++ b/participants/jewgenij_steinhart.json
@@ -1,0 +1,16 @@
+{
+  "name": "Jewgenij Steinhart",
+  "company": "self employed",
+  "when": {
+    "friday": true,
+    "saturday": true
+  },
+  "tags": ["Freelancing", "Parenting", "React", "TypeScript", "Flutter", "Web3", "StandWithUkraine"],
+  "vegan": false,
+  "vegetarian": false,
+  "allergies": "",
+  "what_is_my_connection_to_javascript": "my main programming language",
+  "what_can_i_contribute": "curious participation",
+  "tshirt": "M-L",
+  "twitter": "jeffstei"
+}


### PR DESCRIPTION
I would like to register for JS CraftCamp.    
- [x] My pull request contains a JSON file `$name_or_nickname.json`    
- [x] The JSON file follows the template at [https://github.com/jscraftcamp/website/blob/main/participants/_template.json](https://jscraftcamp.org/register/) and contains the mandatory fields `name`, `when`, `what_is_my_connection_to_javascript` and `what_can_i_contribute`    
- [x] If I can NOT attend, I will either send another pull request removing my JSON file or an e-mail with the subject 'UNREGISTER' to team@jscraftcamp.org
- [x] I agree that the data I enter in the registration can be used for running the event, e.g. make a name tag, count me as participant. I acknowledge that my data are public on GitHub and I agree that I will be listed on the JSCraftCamp website as a participant.
- [x] I agree that photos and videos might be taken and published (e.g. on social media) during the event.
- [x] I understand that I might NOT get a T-Shirt, because they might be in production already
- [x] I agree to wear my mask to protect everyone as much as possible
- [x] I will come and have tested and be covid-negative, at least 24h before I join the event

Are you from a sponsoring company?
- [ ] Yes, I am from company ?????
