### PR TITLE
Fix broken styling in storybook/chromatic

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -27,7 +27,6 @@ jobs:
       - run: node --version
       - run: |
           yarn --frozen-lockfile
-          npm run build-storybook
       - uses: chromaui/action@v1
         with:
           exitOnceUploaded: true

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -28,8 +28,7 @@ module.exports = {
         useRulesZeroElement.options.plugins.push([
           require.resolve("babel-plugin-remove-graphql-queries"),
           {
-            stage:
-              config.mode === `development` ? "develop-html" : "build-html",
+            stage: "develop-html",
             staticQueryDir: "page-data/sq/d",
           },
         ])

--- a/package.json
+++ b/package.json
@@ -58,10 +58,10 @@
     "build": "gatsby build",
     "test": "mocha test",
     "build-storybook": "build-storybook",
-    "storybook": "start-storybook -p 6006",
+    "storybook": "STORYBOOK_BUILD=true start-storybook -p 6006",
     "prestorybook": "npm run extract-gatsby-meta-for-storybook",
     "prebuild-storybook": "npm run prestorybook",
-    "extract-gatsby-meta-for-storybook": "mkdir -p public/static/d ; node ./scripts/extract-gatsby-meta-for-storybook.js public/static/d/63159454.json",
+    "extract-gatsby-meta-for-storybook": "mkdir -p public/page-data/sq/d ; node ./scripts/extract-gatsby-meta-for-storybook.js public/page-data/sq/d/3537562275.json",
     "hygen": "hygen"
   },
   "author": "Michael Zoidl, Robert Hostlowsky and others",

--- a/package.json
+++ b/package.json
@@ -24,19 +24,10 @@
     "react-d3-cloud": "1.0.6",
     "react-dom": "18.2.0",
     "react-helmet": "6.1.0",
-    "sass-mq": "6.0.0",
-    "svg-sprite-loader": "6.0.11",
-    "svgo-loader": "4.0.0"
+    "sass-mq": "6.0.0"
   },
   "devDependencies": {
-    "@storybook/addon-backgrounds": "6.5.16",
-    "@storybook/addon-controls": "6.5.16",
     "@storybook/addon-essentials": "6.5.16",
-    "@storybook/addon-measure": "6.5.16",
-    "@storybook/addon-outline": "6.5.16",
-    "@storybook/addon-toolbars": "6.5.16",
-    "@storybook/addon-viewport": "6.5.16",
-    "@storybook/addons": "6.5.16",
     "@storybook/builder-webpack5": "6.5.16",
     "@storybook/manager-webpack5": "6.5.16",
     "@storybook/preset-scss": "1.0.3",
@@ -47,7 +38,9 @@
     "mocha": "10.2.0",
     "prettier": "2.8.4",
     "recursive-readdir-sync": "1.0.6",
-    "sass": "1.58.3"
+    "sass": "1.58.3",
+    "svg-sprite-loader": "6.0.11",
+    "svgo-loader": "4.0.0"
   },
   "scripts": {
     "develop": "gatsby develop",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "prebuild": "mkdir -p ./public",
     "build": "gatsby build",
     "test": "mocha test",
-    "build-storybook": "build-storybook",
+    "build-storybook": "STORYBOOK_BUILD=true build-storybook",
     "storybook": "STORYBOOK_BUILD=true start-storybook -p 6006",
     "prestorybook": "npm run extract-gatsby-meta-for-storybook",
     "prebuild-storybook": "npm run prestorybook",

--- a/src/components/button/button.js
+++ b/src/components/button/button.js
@@ -1,7 +1,10 @@
 import React from "react"
-import * as style from "./button.module.scss"
+import convert4StorybookIfNeeded from "../../gatsbyStylesHandler"
+import * as gatsbyStyles from "./button.module.scss"
 import Typography from "../typography"
 import cn from "classnames"
+
+const style = convert4StorybookIfNeeded(gatsbyStyles)
 
 const Button = ({ children, className, ...props }) => {
   return (

--- a/src/components/button/button.module.scss
+++ b/src/components/button/button.module.scss
@@ -1,4 +1,4 @@
-@import "src/config";
+@import "../../config";
 
 .root {
   background: $primary-color;

--- a/src/components/mini-headline/mini-headline.js
+++ b/src/components/mini-headline/mini-headline.js
@@ -1,7 +1,10 @@
 import React from "react"
 import cn from "classnames"
 import Typography from "../typography"
-import * as style from "./mini-headline.module.scss"
+import convert4StorybookIfNeeded from "../../gatsbyStylesHandler"
+import * as gatsbyStyles from "./mini-headline.module.scss"
+
+const style = convert4StorybookIfNeeded(gatsbyStyles)
 
 const MiniHeadline = ({ children, className }) => {
   return (

--- a/src/components/page/materialcss-global.scss
+++ b/src/components/page/materialcss-global.scss
@@ -1,5 +1,5 @@
 // JSCraftCamp settings:
-@import "src/config";
+@import "../../config";
 
 /*
   A subset of styles imported from

--- a/src/components/page/page.js
+++ b/src/components/page/page.js
@@ -13,7 +13,10 @@ import "./main.css"
 import "./materialcss-global.scss"
 
 // page component styles
-import * as style from "./page.module.scss"
+import convert4StorybookIfNeeded from "../../gatsbyStylesHandler"
+import * as gatsbyStyles from "./page.module.scss"
+
+const style = convert4StorybookIfNeeded(gatsbyStyles)
 
 const Page = ({ children, title }) => {
   const { site } = useStaticQuery(

--- a/src/components/participant-card/participant-card-reveal/participant-card-reveal.js
+++ b/src/components/participant-card/participant-card-reveal/participant-card-reveal.js
@@ -2,7 +2,10 @@ import React from "react"
 import MiniHeadline from "../../mini-headline"
 import Typography from "../../typography"
 import ParticipantCardTitle from "../participant-card-title"
-import * as style from "./participant-card-reveal.module.scss"
+import convert4StorybookIfNeeded from "../../gatsbyStylesHandler"
+import * as gatsbyStyles from "./participant-card-reveal.module.scss"
+
+const style = convert4StorybookIfNeeded(gatsbyStyles)
 
 const ParticipantCardReveal = ({
   name,

--- a/src/components/participant-card/participant-card-reveal/participant-card-reveal.js
+++ b/src/components/participant-card/participant-card-reveal/participant-card-reveal.js
@@ -2,7 +2,7 @@ import React from "react"
 import MiniHeadline from "../../mini-headline"
 import Typography from "../../typography"
 import ParticipantCardTitle from "../participant-card-title"
-import convert4StorybookIfNeeded from "../../gatsbyStylesHandler"
+import convert4StorybookIfNeeded from "../../../gatsbyStylesHandler"
 import * as gatsbyStyles from "./participant-card-reveal.module.scss"
 
 const style = convert4StorybookIfNeeded(gatsbyStyles)

--- a/src/components/participant-card/participant-card.js
+++ b/src/components/participant-card/participant-card.js
@@ -2,8 +2,11 @@ import React, { useState } from "react"
 import ParticipantCardTitle from "./participant-card-title"
 import ParticipantCardReveal from "./participant-card-reveal/participant-card-reveal"
 import Typography from "../../components/typography"
-import * as style from "./participant-card.module.scss"
+import convert4StorybookIfNeeded from "../../gatsbyStylesHandler"
+import * as gatsbyStyles from "./participant-card.module.scss"
 import cn from "classnames"
+
+const style = convert4StorybookIfNeeded(gatsbyStyles)
 
 const ParticipantCard = ({ data }) => {
   const [revealState, setRevealState] = useState(false)

--- a/src/components/participants-counter/participants-counter.js
+++ b/src/components/participants-counter/participants-counter.js
@@ -1,6 +1,9 @@
 import React from "react"
 import Typography from "../typography"
-import * as style from "./participants-counter.module.scss"
+import convert4StorybookIfNeeded from "../../gatsbyStylesHandler"
+import * as gatsbyStyles from "./participants-counter.module.scss"
+
+const style = convert4StorybookIfNeeded(gatsbyStyles)
 
 const ParticipantsCounter = ({ participants }) => {
   return (

--- a/src/components/participants/participants.js
+++ b/src/components/participants/participants.js
@@ -1,5 +1,8 @@
 import React from "react"
-import * as style from "./participants.module.scss"
+import convert4StorybookIfNeeded from "../../gatsbyStylesHandler"
+import * as gatsbyStyles from "./participants.module.scss"
+
+const style = convert4StorybookIfNeeded(gatsbyStyles)
 
 const Participants = ({ children }) => (
   <div className={style.wrapper}>{children}</div>

--- a/src/components/section/section.js
+++ b/src/components/section/section.js
@@ -1,7 +1,10 @@
 import React from "react"
-import * as style from "./section.module.scss"
+import convert4StorybookIfNeeded from "../../gatsbyStylesHandler"
+import * as gatsbyStyles from "./section.module.scss"
 
 import cn from "classnames"
+
+const style = convert4StorybookIfNeeded(gatsbyStyles)
 
 const Section = ({ className, children }) => (
   <div className={cn(style.root)}>

--- a/src/components/spacer/spacer.js
+++ b/src/components/spacer/spacer.js
@@ -1,7 +1,10 @@
 import React from "react"
-import * as style from "./spacer.module.scss"
+import * as gatsbyStyles from "./spacer.module.scss"
+import convert4StorybookIfNeeded from "../../gatsbyStylesHandler"
 
 import cn from "classnames"
+
+const style = convert4StorybookIfNeeded(gatsbyStyles)
 
 const Spacer = ({ size, className }) => (
   <div className={cn(style.root, className, style[size])} />

--- a/src/components/spacer/spacer.module.scss
+++ b/src/components/spacer/spacer.module.scss
@@ -1,6 +1,6 @@
 @import "~sass-mq/mq.scss";
 
-@import "src/config.scss";
+@import "../../config.scss";
 
 @mixin size($size) {
   height: $size;

--- a/src/components/text-block/text-block.js
+++ b/src/components/text-block/text-block.js
@@ -1,7 +1,10 @@
 import React from "react"
-import * as style from "./text-block.module.scss"
+import convert4StorybookIfNeeded from "../../gatsbyStylesHandler"
+import * as gatsbyStyles from "./text-block.module.scss"
 import Typography from "../typography"
 import cn from "classnames"
+
+const style = convert4StorybookIfNeeded(gatsbyStyles)
 
 const TextBlock = ({
   headline,

--- a/src/components/typography/typography.js
+++ b/src/components/typography/typography.js
@@ -1,7 +1,10 @@
 import React from "react"
-import * as style from "./typography.module.scss"
+import convert4StorybookIfNeeded from "../../gatsbyStylesHandler"
+import * as gatsbyStyles from "./typography.module.scss"
 import cn from "classnames"
 import PropTypes from "prop-types"
+
+const style = convert4StorybookIfNeeded(gatsbyStyles)
 
 const Typography = ({
   className,

--- a/src/components/typography/typography.module.scss
+++ b/src/components/typography/typography.module.scss
@@ -1,4 +1,4 @@
-@import "src/config";
+@import "../../config";
 
 @font-face {
   font-family: "Source Sans Pro";

--- a/src/gatsbyStylesHandler.js
+++ b/src/gatsbyStylesHandler.js
@@ -1,0 +1,8 @@
+const isStorybookBuild = process.env.STORYBOOK_BUILD
+
+export default function convert4StorybookIfNeeded(gatsbyStyles) {
+  if (isStorybookBuild) {
+    return gatsbyStyles.default
+  }
+  return gatsbyStyles
+}

--- a/src/sections/code-of-conduct/code-of-conduct.js
+++ b/src/sections/code-of-conduct/code-of-conduct.js
@@ -1,8 +1,11 @@
 import React from "react"
-import * as style from "./code-of-conduct.module.scss"
+import convert4StorybookIfNeeded from "../../gatsbyStylesHandler"
+import * as gatsbyStyles from "./code-of-conduct.module.scss"
 import Typography from "../../components/typography"
 import Section from "../../components/section"
 import TextBlock from "../../components/text-block"
+
+const style = convert4StorybookIfNeeded(gatsbyStyles)
 
 const CodeOfConduct = () => (
   <Section className={style.root}>

--- a/src/sections/covid-rules/covid-rules.js
+++ b/src/sections/covid-rules/covid-rules.js
@@ -1,9 +1,12 @@
 import React from "react"
-import * as style from "./covid-rules.module.scss"
+import convert4StorybookIfNeeded from "../../gatsbyStylesHandler"
+import * as gatsbyStyles from "./covid-rules.module.scss"
 import Typography from "../../components/typography"
 import Section from "../../components/section"
 import TextBlock from "../../components/text-block"
 import Rule from "./rule"
+
+const style = convert4StorybookIfNeeded(gatsbyStyles)
 
 const CovidRules = () => (
   <Section className={style.root}>

--- a/src/sections/covid-rules/rule/rule.js
+++ b/src/sections/covid-rules/rule/rule.js
@@ -1,6 +1,9 @@
 import React from "react"
 import Typography from "../../../components/typography"
-import * as style from "./rule.module.scss"
+import convert4StorybookIfNeeded from "../../../gatsbyStylesHandler"
+import * as gatsbyStyles from "./rule.module.scss"
+
+const style = convert4StorybookIfNeeded(gatsbyStyles)
 
 const Rule = ({ icon, text }) => {
   return (

--- a/src/sections/explain-sponsoring/explain-sponsoring.js
+++ b/src/sections/explain-sponsoring/explain-sponsoring.js
@@ -5,7 +5,10 @@ import Spacer from "../../components/spacer"
 import TextBlock from "../../components/text-block"
 import Typography from "../../components/typography"
 
-import * as style from "./explain-sponsoring.module.scss"
+import convert4StorybookIfNeeded from "../../gatsbyStylesHandler"
+import * as gatsbyStyles from "./explain-sponsoring.module.scss"
+
+const style = convert4StorybookIfNeeded(gatsbyStyles)
 
 const ExplainSponsoring = () => (
   <Section className={style.root}>

--- a/src/sections/explanation/explanation.js
+++ b/src/sections/explanation/explanation.js
@@ -1,5 +1,6 @@
 import React from "react"
-import * as style from "./explanation.module.scss"
+import convert4StorybookIfNeeded from "../../gatsbyStylesHandler"
+import * as gatsbyStyles from "./explanation.module.scss"
 
 import TextBlock from "../../components/text-block"
 import Typography from "../../components/typography"
@@ -8,6 +9,8 @@ import Icon from "../../components/icon"
 import code from "../../assets/images/code.svg"
 import rocket from "../../assets/images/rocket.svg"
 import camp from "../../assets/images/camp.svg"
+
+const style = convert4StorybookIfNeeded(gatsbyStyles)
 
 const Explanation = () => (
   <>

--- a/src/sections/footer/footer.js
+++ b/src/sections/footer/footer.js
@@ -1,6 +1,7 @@
 import React from "react"
 import { Link } from "gatsby"
-import * as style from "./footer.module.scss"
+import convert4StorybookIfNeeded from "../../gatsbyStylesHandler"
+import * as gatsbyStyles from "./footer.module.scss"
 
 import Icon from "../../components/icon"
 import Typography from "../../components/typography"
@@ -10,6 +11,8 @@ import logo from "../../assets/images/logo.svg"
 import netlify from "../../assets/images/netlify.svg"
 import gatsby from "../../assets/images/gatsby.svg"
 import storybook from "../../assets/images/storybook.svg"
+
+const style = convert4StorybookIfNeeded(gatsbyStyles)
 
 const DEFAULT_BRANCH = "main"
 // env variable will be set by netlify while building, else use default

--- a/src/sections/footer/footer.module.scss
+++ b/src/sections/footer/footer.module.scss
@@ -1,4 +1,4 @@
-@import "src/config";
+@import "../../config";
 
 .footer {
   background: $basic-black;

--- a/src/sections/header/header.js
+++ b/src/sections/header/header.js
@@ -1,10 +1,13 @@
 import React from "react"
-import * as style from "./header.module.scss"
+import convert4StorybookIfNeeded from "../../gatsbyStylesHandler"
+import * as gatsbyStyles from "./header.module.scss"
 
 import Typography from "../../components/typography"
 import Section from "../../components/section"
 
 import { Link } from "gatsby"
+
+const style = convert4StorybookIfNeeded(gatsbyStyles)
 
 const Header = () => (
   <Section className={style.root}>

--- a/src/sections/header/header.module.scss
+++ b/src/sections/header/header.module.scss
@@ -1,4 +1,4 @@
-@import "src/config";
+@import "../../config";
 
 .root {
   display: flex;

--- a/src/sections/intro/intro.js
+++ b/src/sections/intro/intro.js
@@ -4,7 +4,8 @@ import Icon from "../../components/icon"
 import Typography from "../../components/typography"
 import Spacer from "../../components/spacer"
 
-import * as style from "./intro.module.scss"
+import convert4StorybookIfNeeded from "../../gatsbyStylesHandler"
+import * as gatsbyStyles from "./intro.module.scss"
 
 import logo from "../../assets/images/logo.svg"
 import twitter from "../../assets/images/twitter.svg"
@@ -13,6 +14,8 @@ import discord from "../../assets/images/discord.svg"
 import skyline from "../../assets/images/skyline.svg"
 import TextBlock from "../../components/text-block"
 import MiniHeadline from "../../components/mini-headline"
+
+const style = convert4StorybookIfNeeded(gatsbyStyles)
 
 const Intro = () => (
   <div className={style.root}>

--- a/src/sections/post-event/post-event.js
+++ b/src/sections/post-event/post-event.js
@@ -1,6 +1,7 @@
 import React from "react"
 
-import * as style from "./post-event.module.scss"
+import convert4StorybookIfNeeded from "../../gatsbyStylesHandler"
+import * as gatsbyStyles from "./post-event.module.scss"
 
 import twitter from "../../assets/images/twitter.svg"
 import github from "../../assets/images/github.svg"
@@ -10,6 +11,8 @@ import Spacer from "../../components/spacer"
 import TextBlock from "../../components/text-block"
 import logo from "../../assets/images/logo.svg"
 import Typography from "../../components/typography"
+
+const style = convert4StorybookIfNeeded(gatsbyStyles)
 
 const PostEvent = () => (
   <div className={style.root}>

--- a/src/sections/schedule/row/row.js
+++ b/src/sections/schedule/row/row.js
@@ -1,5 +1,8 @@
 import React from "react"
-import * as style from "./row.module.scss"
+import convert4StorybookIfNeeded from "../../../gatsbyStylesHandler"
+import * as gatsbyStyles from "./row.module.scss"
+
+const style = convert4StorybookIfNeeded(gatsbyStyles)
 
 const Row = ({ time, children }) => {
   return (

--- a/src/sections/schedule/schedule.js
+++ b/src/sections/schedule/schedule.js
@@ -1,8 +1,11 @@
 import React from "react"
-import * as style from "./schedule.module.scss"
+import convert4StorybookIfNeeded from "../../gatsbyStylesHandler"
+import * as gatsbyStyles from "./schedule.module.scss"
 import TextBlock from "../../components/text-block"
 import MiniHeadline from "../../components/mini-headline"
 import Row from "./row"
+
+const style = convert4StorybookIfNeeded(gatsbyStyles)
 
 const Schedule = () => (
   <TextBlock headline="Schedule">

--- a/src/sections/sponsors/sponsors.js
+++ b/src/sections/sponsors/sponsors.js
@@ -2,7 +2,10 @@ import React from "react"
 
 import TextBlock from "../../components/text-block"
 
-import * as style from "./sponsors.module.scss"
+import convert4StorybookIfNeeded from "../../gatsbyStylesHandler"
+import * as gatsbyStyles from "./sponsors.module.scss"
+
+const style = convert4StorybookIfNeeded(gatsbyStyles)
 
 const Sponsors = () => {
   const sponsors = [

--- a/src/sections/sponsors/sponsors.js
+++ b/src/sections/sponsors/sponsors.js
@@ -60,10 +60,13 @@ const Sponsors = () => {
         {sponsors.map((s, i) => {
           return (
             <div className={style.col} key={s.name}>
-              <a href={s.link} rel="noopener noreferrer" target="_blank">
-                <div className={style.image}>
-                  <img alt={s.name} src={s.src} width="100%" />
-                </div>
+              <a
+                href={s.link}
+                rel="noopener noreferrer"
+                target="_blank"
+                className={style.image}
+              >
+                <img alt={s.name} src={s.src} width="100%" />
               </a>
             </div>
           )

--- a/src/sections/sponsors/sponsors.module.scss
+++ b/src/sections/sponsors/sponsors.module.scss
@@ -2,15 +2,20 @@
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
-  gap: 3rem 4rem;
+  gap: 2rem 3rem;
 }
 
 .col {
   display: flex;
   align-items: center;
   flex-basis: 300px;
+  padding: 2rem;
+  height: 4.5rem;
+  background-color: #fff
 }
 
 .image {
-  width: 100%;
+  // avoid an unwanted tiny extra space or shift of the logo
+  // inside of the white container
+  line-height: 0;
 }

--- a/src/sections/team/team.js
+++ b/src/sections/team/team.js
@@ -2,10 +2,13 @@ import React from "react"
 
 import data from "../../data.json"
 
-import * as styles from "./team.module.scss"
+import convert4StorybookIfNeeded from "../../gatsbyStylesHandler"
+import * as gatsbyStyles from "./team.module.scss"
+
+const style = convert4StorybookIfNeeded(gatsbyStyles)
 
 export const Team = () => (
-  <div className={styles.theTeam}>
+  <div className={style.theteam}>
     {data.theteam.map(({ name, photo, email }) => {
       return (
         <div key={name}>
@@ -14,7 +17,7 @@ export const Team = () => (
           )}
           <div>{name}</div>
           {email && (
-            <a className={styles.mail} href={"mailto:" + email} title={email}>
+            <a className={style.mail} href={"mailto:" + email} title={email}>
               {email}
             </a>
           )}

--- a/src/sections/team/team.module.scss
+++ b/src/sections/team/team.module.scss
@@ -22,7 +22,7 @@
   white-space: nowrap;
 }
 
-.the-team {
+.theteam {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(min(250px, 100%), 1fr));
   grid-template-rows: repeat(auto-fit, min-content);

--- a/yarn.lock
+++ b/yarn.lock
@@ -10753,11 +10753,6 @@ markdown-escapes@^1.0.0:
   resolved "https://registry.yarnpkg.com/markdown-escapes/-/markdown-escapes-1.0.4.tgz#c95415ef451499d7602b91095f3c8e8975f78535"
   integrity sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==
 
-materialize-css@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/materialize-css/-/materialize-css-1.0.0.tgz#8d5db1c4a81c6d65f3b2e2ca83a8e08daa24d1be"
-  integrity sha512-4/oecXl8y/1i8RDZvyvwAICyqwNoKU4or5uf8uoAd74k76KzZ0Llym4zhJ5lLNUskcqjO0AuMcvNyDkpz8Z6zw==
-
 md5.js@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"


### PR DESCRIPTION
After migrating to Gatsby5, the css-modules styling broke in storybook / incompatible way how it was exported or imported in react components in Gatsby:

```
import * as style from './styling.scss'

export default function Component = () => (
  <div className={style.root}
);
```

When used within storybook it needs to be:

```
import * as style from './styling.scss'

export default function Component = () => (
  <div className={style.default.root}
);
```

So, effectively a modules import  configuration issue - but honestly I tried different settings within webpack / cssloader / sassloader - but no luck 😞 


## Workaround/Quick fix solution

Simply by adding a wrapper which internally does the magic, when run in storybook:
see [src/gatsbyStylesHandler.js]

Worx, so, at least helps to re-enable storybook as long as we still use this repo...