### PR TITLE
chore: add dgrabla as participant

### DIFF
--- a/participants/dgrabla.json
+++ b/participants/dgrabla.json
@@ -1,0 +1,22 @@
+{
+	"name": "David Grajal",
+	"company": "David Grajal",
+	"when": {
+		"friday": false,
+    "saturday": true
+	},
+	"iCanTakeNotesDuringSessions": true,
+	"tags": ["Vue", "gRPC", "CSS color functions", "Nvim"],
+	"vegan": false,
+	"vegetarian": false,
+	"allergies": [],
+	"whatIsMyConnectionToJavascript": "Full time frontend developer since 2010",
+	"whatCanIContribute": "Discussions about FE",
+	"tShirt": {
+		"size": "M",
+		"type": "regular"
+	},
+	"twitter": "dgrabla",
+	"mastodon": "https://mastodon.social/@dgrabla",
+	"website": "https://www.davidgrajal.com"
+}


### PR DESCRIPTION
I would like to register for JS CraftCamp.

- [X] My pull request contains a JSON file `$name_or_nickname.json`
- [X] The JSON file follows the template at [https://github.com/jscraftcamp/website/blob/main/participants/\_template.json](https://jscraftcamp.org/register/) and contains the mandatory fields like `name`, `when`, `whatIsMyConnectionToJavascript` and `whatCanIContribute`
- [X] If I can NOT attend, I will either send another pull request removing my JSON file or an e-mail with the subject 'UNREGISTER' to team@jscraftcamp.org
- [X] I agree that the data I enter in the registration can be used for running the event, e.g. make a name tag, count me as participant. I acknowledge that my data are public on GitHub and I agree that I will be listed on the JSCraftCamp website as a participant.
- [X] I agree that photos and videos might be taken and published (e.g. on social media) during the event.
- [X] I understand that I might NOT get a T-Shirt, because they might be in production already
- [X] I asked my company about sponsoring (see open items at: https://github.com/orgs/jscraftcamp/projects/5/views/1)

Are you from a sponsoring company?

- [ ] Yes, I am from company
