### PR TITLE
Add Akash to participants

### DIFF
--- a/participants/akash-sawant.json
+++ b/participants/akash-sawant.json
@@ -1,0 +1,25 @@
+{
+    "name": "Akash Sawant",
+    // optional
+    "company": "optilyz GmbH",
+    // required
+    "when": {
+        "friday": true,
+        "saturday": true
+    },
+    // required
+    "iCanTakeNotesDuringSessions": true,
+    // required - at least one
+    "tags": ["Typescript", "React", "Node", "AWS"],
+    // required
+    "whatIsMyConnectionToJavascript": "I use JS in my professional life.",
+    // required
+    "whatCanIContribute": "I can share my knowledge aroung testing react components, redux, node",
+    // optional
+    "tShirt": {
+        "size": "S",
+        "type": "fitted"
+    },
+    // optional
+    "twitter": "sakash321"
+}


### PR DESCRIPTION
I would like to register for JS CraftCamp.

- [x] My pull request contains a JSON file `$name_or_nickname.json`
- [x] The JSON file follows the template at [https://github.com/jscraftcamp/website/blob/main/participants/\_template.json](https://jscraftcamp.org/register/) and contains the mandatory fields like `name`, `when`, `whatIsMyConnectionToJavascript` and `whatCanIContribute`
- [x] If I can NOT attend, I will either send another pull request removing my JSON file or an e-mail with the subject 'UNREGISTER' to team@jscraftcamp.org
- [x] I agree that the data I enter in the registration can be used for running the event, e.g. make a name tag, count me as participant. I acknowledge that my data are public on GitHub and I agree that I will be listed on the JSCraftCamp website as a participant.
- [x] I agree that photos and videos might be taken and published (e.g. on social media) during the event.
- [x] I understand that I might NOT get a T-Shirt, because they might be in production already
- [ ] I asked my company about sponsoring (see open items at: https://github.com/orgs/jscraftcamp/projects/5/views/1)

Are you from a sponsoring company?

- [ ] Yes, I am from company ?????
