### PR TITLE
feat: registration Artur Ptaszek

### DIFF
--- a/participants/artur_ptaszek.json
+++ b/participants/artur_ptaszek.json
@@ -1,0 +1,20 @@
+{
+	"name": "Artur Ptaszek",
+	"company": "Port Blue Sky",
+	"when": {
+		"friday": true,
+		"saturday": true
+	},
+	"iCanTakeNotesDuringSessions": false,
+	"tags": ["React", "TypeScript", "TanStack Query", "Rust", "tmux", "VIM", "k8s", "Docker", "OpenID Connect"],
+	"vegan": false,
+	"vegetarian": false,
+	"whatIsMyConnectionToJavascript": "I work TS/JS Full Stack for over 10 years, but as a enthusiast much more.",
+	"whatCanIContribute": "Generating a client code based on OpenAPI spec, Doken - my tool for getting OAuth2/OpenID connect token directly in a console for all authentication grants, contributing in discussions.",
+	"tShirt": {
+		"size": "L",
+		"type": "regular"
+	},
+	"twitter": "RiddleMan",
+	"website": "https://ptaszek.dev"
+}


### PR DESCRIPTION
I would like to register for JS CraftCamp.

- [x] My pull request contains a JSON file `$name_or_nickname.json`
- [x] The JSON file follows the template at [https://github.com/jscraftcamp/website/blob/main/participants/\_template.json](https://jscraftcamp.org/register/) and contains the mandatory fields like `name`, `when`, `whatIsMyConnectionToJavascript` and `whatCanIContribute`
- [x] If I can NOT attend, I will either send another pull request removing my JSON file or an e-mail with the subject 'UNREGISTER' to team@jscraftcamp.org
- [x] I agree that the data I enter in the registration can be used for running the event, e.g. make a name tag, count me as participant. I acknowledge that my data are public on GitHub and I agree that I will be listed on the JSCraftCamp website as a participant.
- [x] I agree that photos and videos might be taken and published (e.g. on social media) during the event.
- [x] I understand that I might NOT get a T-Shirt, because they might be in production already
- [ ] I asked my company about sponsoring (see open items at: https://github.com/orgs/jscraftcamp/projects/5/views/1)

Are you from a sponsoring company?

- [ ] Yes, I am from company ?????
