### PR TITLE
Add 3XL T-Shirt Size option

### DIFF
--- a/participants/_template.json
+++ b/participants/_template.json
@@ -28,7 +28,7 @@
 	"whatCanIContribute": "???",
 	// if you want a T-Shirt we need your size and variant preference (optional)
 	"tShirt": {
-		// S | M | L | XL | XXL
+		// S | M | L | XL | 2XL | 3XL
 		"size": "S",
 		// fitted (also known as waist cut or women variant) or regular
 		"type": "fitted"

--- a/participants/alexander_wiesinger.json
+++ b/participants/alexander_wiesinger.json
@@ -28,7 +28,7 @@
 	"whatCanIContribute": "Good knowledge of angular.",
 	// if you want a T-Shirt we need your size and variant preference (optional)
 	"tShirt": {
-		// S | M | L | XL | XXL
+		// S | M | L | XL | 2XL | 3XL
 		"size": "L",
 		// fitted (also known as waist cut or women variant) or regular
 		"type": "regular"

--- a/participants/bernd.json
+++ b/participants/bernd.json
@@ -26,7 +26,7 @@
 	"whatCanIContribute": "Sessions about SolidJS & Tauri",
 	// if you want a T-Shirt we need your size and variant preference (optional)
 	"tShirt": {
-		// S | M | L | XL | XXL
+		// S | M | L | XL | 2XL | 3XL
 		"size": "L",
 		// fitted (also known as waist cut or women variant) or regular
 		"type": "regular"

--- a/participants/brigitte-jellinek.json
+++ b/participants/brigitte-jellinek.json
@@ -28,8 +28,8 @@
 	"whatCanIContribute": "join discussions, take notes, bring board games, maybe give a talk",
 	// if you want a T-Shirt we need your size and variant preference (optional)
 	"tShirt": {
-		// S | M | L | XL | XXL
-		"size": "XXL",
+		// S | M | L | XL | 2XL | 3XL
+		"size": "2XL",
 		// fitted (also known as waist cut or women variant) or regular
 		"type": "fitted"
 	},

--- a/participants/christian_waldmann.json
+++ b/participants/christian_waldmann.json
@@ -28,7 +28,7 @@
 	"whatCanIContribute": "Experience in building, developing, maintaining and managing an enterprise Angular application",
 	// if you want a T-Shirt we need your size and variant preference (optional)
 	"tShirt": {
-		// S | M | L | XL | XXL
+		// S | M | L | XL | 2XL | 3XL
 		"size": "M",
 		// fitted (also known as waist cut or women variant) or regular
 		"type": "regular"

--- a/participants/fabian_biberger.json
+++ b/participants/fabian_biberger.json
@@ -26,7 +26,7 @@
 	"whatCanIContribute": "I could sum up some points about how to build more sustainable web applications.",
 	// if you want a T-Shirt we need your size and variant preference (optional)
 	"tShirt": {
-		// S | M | L | XL | XXL
+		// S | M | L | XL | 2XL | 3XL
 		"size": "L",
 		// fitted (also known as waist cut or women variant) or regular
 		"type": "regular"

--- a/participants/jonas_kaltenbach.json
+++ b/participants/jonas_kaltenbach.json
@@ -22,7 +22,7 @@
 	"whatCanIContribute": "Experience with making large products accessible and performance optimization of single page applications",
 	// if you want a T-Shirt we need your size and variant preference (optional)
 	"tShirt": {
-		// S | M | L | XL | XXL
+		// S | M | L | XL | 2XL | 3XL
 		"size": "L",
 		// fitted (also known as waist cut or women variant) or regular
 		"type": "regular"

--- a/participants/marco.json
+++ b/participants/marco.json
@@ -19,7 +19,7 @@
   "whatIsMyConnectionToJavascript": "I use JS for a long time and love to be part of the community",
   "whatCanIContribute": "Session about #SchoolsOfTDD and Domain Modelling",
   "tShirt": {
-    "size": "XXL",
+    "size": "2XL",
     "type": "regular"
   },
   "twitter": "marcoemrich",

--- a/participants/matthias_stemmler.json
+++ b/participants/matthias_stemmler.json
@@ -27,7 +27,7 @@
 	"whatCanIContribute": "Experience in React and JS/TS in general",
 	// if you want a T-Shirt we need your size and variant preference (optional)
 	"tShirt": {
-		// S | M | L | XL | XXL
+		// S | M | L | XL | 2XL | 3XL
 		"size": "M",
 		// fitted (also known as waist cut or women variant) or regular
 		"type": "regular"

--- a/participants/mlgr.json
+++ b/participants/mlgr.json
@@ -26,8 +26,8 @@
 	"whatCanIContribute": "Info and discussions about web tech",
 	// if you want a T-Shirt we need your size and variant preference (optional)
 	"tShirt": {
-		// S | M | L | XL | XXL
-		"size": "XXL",
+		// S | M | L | XL | 2XL | 3XL
+		"size": "2XL",
 		// fitted (also known as waist cut or women variant) or regular
 		"type": "regular"
 	},

--- a/participants/philip-saa.json
+++ b/participants/philip-saa.json
@@ -11,7 +11,7 @@
 	"whatIsMyConnectionToJavascript": "I joined the internet in 1996 and I am currently working with JavaScript/TypeScript",
 	"whatCanIContribute": "I can help you with hurdles you might have when it comes to creating audio/video content.",
 	"tShirt": {
-		"size": "2XL",
+		"size": "3XL",
 		"type": "regular"
 	},
 	"twitter": "cowglow",

--- a/participants/philip-saa.json
+++ b/participants/philip-saa.json
@@ -11,7 +11,7 @@
 	"whatIsMyConnectionToJavascript": "I joined the internet in 1996 and I am currently working with JavaScript/TypeScript",
 	"whatCanIContribute": "I can help you with hurdles you might have when it comes to creating audio/video content.",
 	"tShirt": {
-		"size": "XXL",
+		"size": "2XL",
 		"type": "regular"
 	},
 	"twitter": "cowglow",

--- a/participants/theabdolah.json
+++ b/participants/theabdolah.json
@@ -12,7 +12,7 @@
 	"whatIsMyConnectionToJavascript": "I used to hate it, but then I found my love in it when my Team Leader forced me to use it.",
 	"whatCanIContribute": "I am not good at talks, but I have a decent knowledge about TypeScript and Python, I can help with that.",
 	"tShirt": {
-		"size": "XXL",
+		"size": "2XL",
 		"type": "regular"
 	}
 }

--- a/src/lib/participants/participant-schema.ts
+++ b/src/lib/participants/participant-schema.ts
@@ -50,7 +50,10 @@ export const ParticipantSchema = z
 		tShirt: z
 			.object({
 				type: z.preprocess((v) => String(v).toLowerCase(), z.enum(['fitted', 'regular'])),
-				size: z.preprocess((v) => String(v).toUpperCase(), z.enum(['S', 'M', 'L', 'XL', 'XXL']))
+				size: z.preprocess(
+					(v) => String(v).toUpperCase(),
+					z.enum(['S', 'M', 'L', 'XL', '2XL', '3XL'])
+				)
 			})
 			.nullish(),
 		twitter: z.preprocess(

--- a/src/routes/registration/+page.svelte
+++ b/src/routes/registration/+page.svelte
@@ -52,7 +52,7 @@
     "whatCanIContribute": "???",
     // optional
     "tShirt": {
-        "size": "S/M/L/XL/XXL",
+        "size": "S/M/L/XL/2XL/3XL",
         "type": "fitted/regular"
     },
     // optional
@@ -105,8 +105,8 @@
 				<dd>
 					If you want a t-shirt, please fill out the <code>size</code> and <code>type</code> values.
 					<code>tShirt.size</code>
-					can be one of <code>"S"</code>, <code>"M"</code>, <code>"L"</code>,<code>"XL"</code> or
-					<code>"XXL"</code>. <code>tShirt.type</code> can be <code>"fitted"</code> for a waist cut
+					can be one of <code>"S"</code>, <code>"M"</code>, <code>"L"</code>, <code>"XL"</code>, <code>"2XL"</code> or
+					<code>"3XL"</code>. <code>tShirt.type</code> can be <code>"fitted"</code> for a waist cut
 					(also known as women variant) or <code>"regular"</code>.
 				</dd>
 


### PR DESCRIPTION
I am submitting this PR so that our T-shirt template includes `3XL shirt sizes`. Currently, the template only offers sizes up to 2XL, which may exclude heavier participants, including myself. My hope is that by adding 3XL sizes, participants will get a shirt that they can actually wear. The includes updating event registration page, the participant json template and the schema for the json validation. This change demonstrates our commitment to inclusivity and enhances the overall participant experience.

Thank you for your consideration.

