### PR TITLE
Create meaku.json

### DIFF
--- a/participants/meaku.json
+++ b/participants/meaku.json
@@ -1,0 +1,20 @@
+{
+	"name": "Michael Jaser",
+	"company": "Peerigon",
+	"when": {
+		"friday": true,
+		"saturday": true 
+	},
+	"iCanTakeNotesDuringSessions": true,
+	"tags": ["Node.js", "web-standards", "edge-workers", "green-software", ""],
+	"vegan": false,
+	"vegetarian": true,
+	"allergies": [],
+	"whatIsMyConnectionToJavascript": "We've started a JavaScript company 12 years ago and still love it.",
+	// what can you contribute to the bar camp (required)
+	"whatCanIContribute": "Passion for a sustainable web, humans and exciting tech in general.",
+	// your Twitter handle - must match regex ^[a-zA-Z_]{1}[a-zA-Z0-9_]{0,14}$ (optional)
+	"twitter": "mmeaku",
+	// your website URL or other social media (optional)
+	"website": "https://www.peerigon.com"
+}


### PR DESCRIPTION
I would like to register for JS CraftCamp.

- [x] My pull request contains a JSON file `$name_or_nickname.json`
- [x] The JSON file follows the template at [https://github.com/jscraftcamp/website/blob/main/participants/\_template.json](https://jscraftcamp.org/register/) and contains the mandatory fields like `name`, `when`, `whatIsMyConnectionToJavascript` and `whatCanIContribute`
- [x] If I can NOT attend, I will either send another pull request removing my JSON file or an e-mail with the subject 'UNREGISTER' to team@jscraftcamp.org
- [x] I agree that the data I enter in the registration can be used for running the event, e.g. make a name tag, count me as participant. I acknowledge that my data are public on GitHub and I agree that I will be listed on the JSCraftCamp website as a participant.
- [x] I agree that photos and videos might be taken and published (e.g. on social media) during the event.
- [x] I understand that I might NOT get a T-Shirt, because they might be in production already
- [x] I asked my company about sponsoring (see open items at: https://github.com/orgs/jscraftcamp/projects/5/views/1)

Are you from a sponsoring company?

- [x] Yes, I am from company [Peerigon](https://peerigon.com)
