### PR TITLE
add daniel hilpoltsteiner to participants

### DIFF
--- a/participants/daniel_hilpoltsteiner.json
+++ b/participants/daniel_hilpoltsteiner.json
@@ -1,0 +1,19 @@
+{
+	"name": "Daniel Hilpoltsteiner",
+	"company": "Hochschule Landshut",
+	"when": {
+		"friday": true,
+		"saturday": true
+	},
+	"iCanTakeNotesDuringSessions": true,
+	"tags": ["Angular", "RxJS", "NestJS", "TypeScript"],
+	"vegan": false,
+	"vegetarian": false,
+	"whatIsMyConnectionToJavascript": "My favorite Programming Language.",
+	"whatCanIContribute": "I can talk about my experience with Angular / NestJS.",
+	"tShirt": {
+		"size": "XL",
+		"type": "regular"
+	},
+	"twitter": "HilpoltsteinerD"
+}


### PR DESCRIPTION
I would like to register for JS CraftCamp.

- [x] My pull request contains a JSON file `$name_or_nickname.json`
- [x] The JSON file follows the template at [https://github.com/jscraftcamp/website/blob/main/participants/\_template.json](https://jscraftcamp.org/register/) and contains the mandatory fields like `name`, `when`, `whatIsMyConnectionToJavascript` and `whatCanIContribute`
- [x] If I can NOT attend, I will either send another pull request removing my JSON file or an e-mail with the subject 'UNREGISTER' to team@jscraftcamp.org
- [x] I agree that the data I enter in the registration can be used for running the event, e.g. make a name tag, count me as participant. I acknowledge that my data are public on GitHub and I agree that I will be listed on the JSCraftCamp website as a participant.
- [x] I agree that photos and videos might be taken and published (e.g. on social media) during the event.
- [x] I understand that I might NOT get a T-Shirt, because they might be in production already
- [ ] I asked my company about sponsoring (see open items at: https://github.com/orgs/jscraftcamp/projects/5/views/1)

Are you from a sponsoring company?

- [ ] Yes, I am from company ?????
