### PR TITLE
Adding participant: Larisa Antsifrova

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,11 @@
 I would like to register for JS CraftCamp.
 
-- [x] My pull request contains a JSON file `$name_or_nickname.json`
-- [x] The JSON file follows the template at [https://github.com/jscraftcamp/website/blob/main/participants/\_template.json](https://jscraftcamp.org/register/) and contains the mandatory fields like `name`, `when`, `whatIsMyConnectionToJavascript` and `whatCanIContribute`
-- [x] If I can NOT attend, I will either send another pull request removing my JSON file or an e-mail with the subject 'UNREGISTER' to team@jscraftcamp.org
-- [x] I agree that the data I enter in the registration can be used for running the event, e.g. make a name tag, count me as participant. I acknowledge that my data are public on GitHub and I agree that I will be listed on the JSCraftCamp website as a participant.
-- [x] I agree that photos and videos might be taken and published (e.g. on social media) during the event.
-- [x] I understand that I might NOT get a T-Shirt, because they might be in production already
+- [ ] My pull request contains a JSON file `$name_or_nickname.json`
+- [ ] The JSON file follows the template at [https://github.com/jscraftcamp/website/blob/main/participants/\_template.json](https://jscraftcamp.org/register/) and contains the mandatory fields like `name`, `when`, `whatIsMyConnectionToJavascript` and `whatCanIContribute`
+- [ ] If I can NOT attend, I will either send another pull request removing my JSON file or an e-mail with the subject 'UNREGISTER' to team@jscraftcamp.org
+- [ ] I agree that the data I enter in the registration can be used for running the event, e.g. make a name tag, count me as participant. I acknowledge that my data are public on GitHub and I agree that I will be listed on the JSCraftCamp website as a participant.
+- [ ] I agree that photos and videos might be taken and published (e.g. on social media) during the event.
+- [ ] I understand that I might NOT get a T-Shirt, because they might be in production already
 - [ ] I asked my company about sponsoring (see open items at: https://github.com/orgs/jscraftcamp/projects/5/views/1)
 
 Are you from a sponsoring company?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,13 @@
 I would like to register for JS CraftCamp.
 
-- [ ] My pull request contains a JSON file `$name_or_nickname.json`
-- [ ] The JSON file follows the template at [https://github.com/jscraftcamp/website/blob/main/participants/\_template.json](https://jscraftcamp.org/register/) and contains the mandatory fields like `name`, `when`, `whatIsMyConnectionToJavascript` and `whatCanIContribute`
-- [ ] If I can NOT attend, I will either send another pull request removing my JSON file or an e-mail with the subject 'UNREGISTER' to team@jscraftcamp.org
-- [ ] I agree that the data I enter in the registration can be used for running the event, e.g. make a name tag, count me as participant. I acknowledge that my data are public on GitHub and I agree that I will be listed on the JSCraftCamp website as a participant.
-- [ ] I agree that photos and videos might be taken and published (e.g. on social media) during the event.
-- [ ] I understand that I might NOT get a T-Shirt, because they might be in production already
+- [x] My pull request contains a JSON file `$name_or_nickname.json`
+- [x] The JSON file follows the template at [https://github.com/jscraftcamp/website/blob/main/participants/\_template.json](https://jscraftcamp.org/register/) and contains the mandatory fields like `name`, `when`, `whatIsMyConnectionToJavascript` and `whatCanIContribute`
+- [x] If I can NOT attend, I will either send another pull request removing my JSON file or an e-mail with the subject 'UNREGISTER' to team@jscraftcamp.org
+- [x] I agree that the data I enter in the registration can be used for running the event, e.g. make a name tag, count me as participant. I acknowledge that my data are public on GitHub and I agree that I will be listed on the JSCraftCamp website as a participant.
+- [x] I agree that photos and videos might be taken and published (e.g. on social media) during the event.
+- [x] I understand that I might NOT get a T-Shirt, because they might be in production already
 - [ ] I asked my company about sponsoring (see open items at: https://github.com/orgs/jscraftcamp/projects/5/views/1)
 
 Are you from a sponsoring company?
 
-- [ ] Yes, I am from company ?????
+- [ ] Yes, I am from company

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,4 +10,4 @@ I would like to register for JS CraftCamp.
 
 Are you from a sponsoring company?
 
-- [ ] Yes, I am from company
+- [ ] Yes, I am from company ?????

--- a/participants/larisa_antsifrova.json
+++ b/participants/larisa_antsifrova.json
@@ -1,0 +1,20 @@
+{
+	"name": "Larisa Antsifrova",
+	"company": "SKELAR",
+	"when": {
+		"friday": true,
+		"saturday": true
+	},
+	"iCanTakeNotesDuringSessions": true,
+	"tags": ["VueJS", "React", "Angular", "NodeJS", "TypeScript", "GraphQL", "Accessibility", "Architecture", "UI/UX"],
+	"vegan": false,
+	"vegetarian": false,
+	"allergies": ["None"],
+	"whatIsMyConnectionToJavascript": "I work as a Frontend Developer \uD83E\uDD13. Everyday I create user interfaces with the help of VueJS framework \uD83C\uDF08. Besides, I participate in educational initiatives: facilitate meetups, have lectures, prepare presentations on topics related to JS and the world of Frontend \uD83D\uDCDA.",
+	"whatCanIContribute": "1️⃣ I could share my expertise in VueJS.  2️⃣ I would love to held discussions on Clean code, different types of architecture and/or patterns.  3️⃣ Moreover, I could organize a quiz on JS and Frontend development for participants.  4️⃣ Finally, I could help with organisation moments: taking notes, taking pictures of the activities.",
+	"tShirt": {
+		"size": "S",
+		"type": "regular"
+	},
+	"website": "https://www.linkedin.com/in/larisa-antsifrova/"
+}


### PR DESCRIPTION
I would like to register for JS CraftCamp.

- [x] My pull request contains a JSON file `$name_or_nickname.json`
- [x] The JSON file follows the template at [https://github.com/jscraftcamp/website/blob/main/participants/\_template.json](https://jscraftcamp.org/register/) and contains the mandatory fields like `name`, `when`, `whatIsMyConnectionToJavascript` and `whatCanIContribute`
- [x] If I can NOT attend, I will either send another pull request removing my JSON file or an e-mail with the subject 'UNREGISTER' to team@jscraftcamp.org
- [x] I agree that the data I enter in the registration can be used for running the event, e.g. make a name tag, count me as participant. I acknowledge that my data are public on GitHub and I agree that I will be listed on the JSCraftCamp website as a participant.
- [x] I agree that photos and videos might be taken and published (e.g. on social media) during the event.
- [x] I understand that I might NOT get a T-Shirt, because they might be in production already
- [ ] I asked my company about sponsoring (see open items at: https://github.com/orgs/jscraftcamp/projects/5/views/1)

Are you from a sponsoring company?

- [ ] Yes, I am from company
