### PR TITLE
Add: bene_koehler.json

### DIFF
--- a/participants/bene_koehler.json
+++ b/participants/bene_koehler.json
@@ -1,0 +1,38 @@
+
+
+{
+    // required
+    "name": "Bene Köhler",
+    // optional
+    "company": "Peerigon GmbH",
+    // required
+    "when": {
+        "friday": true,
+        "saturday": true
+    },
+    // required
+    "iCanTakeNotesDuringSessions": false,
+    // required - at least one
+    "tags": ["Typescript", "React", "Next", "GraphQL", "WebGl", "three.js", "r3f"],
+    // optional
+    "vegan": true,
+    // optional
+    "vegetarian": false,
+    // optional
+    "allergies": [],
+    // required
+    "whatIsMyConnectionToJavascript": "I want to create accessible experiences for everyone and maybe even learn something new",
+    // required
+    "whatCanIContribute": "hopefully answer some questions i get asked",
+    // optional
+    "tShirt": {
+        "size": "L",
+        "type": "regular"
+    },
+    // optional
+    "twitter": "yourhandle",
+    // optional
+    "mastodon": "your Mastodon URL",
+    // optional
+    "website": "your website URL"
+}

--- a/participants/bene_koehler.json
+++ b/participants/bene_koehler.json
@@ -30,9 +30,9 @@
         "type": "regular"
     },
     // optional
-    "twitter": "yourhandle",
+    "twitter": null,
     // optional
-    "mastodon": "your Mastodon URL",
+    "mastodon": null,
     // optional
-    "website": "your website URL"
+    "website": null
 }


### PR DESCRIPTION
I would like to register for JS CraftCamp.

- [x] My pull request contains a JSON file `$name_or_nickname.json`
- [x] The JSON file follows the template at [https://github.com/jscraftcamp/website/blob/main/participants/\_template.json](https://jscraftcamp.org/register/) and contains the mandatory fields like `name`, `when`, `whatIsMyConnectionToJavascript` and `whatCanIContribute`
- [x] If I can NOT attend, I will either send another pull request removing my JSON file or an e-mail with the subject 'UNREGISTER' to team@jscraftcamp.org
- [x] I agree that the data I enter in the registration can be used for running the event, e.g. make a name tag, count me as participant. I acknowledge that my data are public on GitHub and I agree that I will be listed on the JSCraftCamp website as a participant.
- [x] I agree that photos and videos might be taken and published (e.g. on social media) during the event.
- [x] I understand that I might NOT get a T-Shirt, because they might be in production already
- [x] I asked my company about sponsoring (see open items at: https://github.com/orgs/jscraftcamp/projects/5/views/1)

Are you from a sponsoring company?

- [x] Yes, I am from Peerigon GmbH
