### PR TITLE
Add Fabian Rapp to participants

### DIFF
--- a/participants/fabian_rapp.json
+++ b/participants/fabian_rapp.json
@@ -1,0 +1,34 @@
+// Please provide your info in your own .json file.
+// See https://jscraftcamp.org/registration for more information
+{
+	// your name / nickname (required)
+	"name": "Fabian Rapp",
+	// optional company name (required)
+	"company": "inovex GmbH",
+	// either both days or at least one day has to be set to true
+	"when": {
+		// 2023-06-30
+		"friday": true,
+		// 2023-07-01
+		"saturday": true
+	},
+	// if you are willing to take session notes and publish them to github (required)
+	"iCanTakeNotesDuringSessions": true,
+	// your current interests (JS and in general) (required)
+	"tags": ["ReactJS", "NextJS"],
+	// if you only eat vegan food (optional)
+	"vegan": false,
+	// if you only eat vegan or vegetarian food (optional)
+	"vegetarian": false,
+	// tell us a few words how JavaScript affects you (required)
+	"whatIsMyConnectionToJavascript": "I develop with JS in my free time.",
+	// what can you contribute to the bar camp (required)
+	"whatCanIContribute": "I can talk about my experience with ReactJS and NextJS.",
+	// if you want a T-Shirt we need your size and variant preference (optional)
+	"tShirt": {
+		// S | M | L | XL | 2XL | 3XL
+		"size": "L",
+		// fitted (also known as waist cut or women variant) or regular
+		"type": "regular"
+	}
+}


### PR DESCRIPTION
I would like to register for JS CraftCamp.

- [x] My pull request contains a JSON file `$name_or_nickname.json`
- [x] The JSON file follows the template at [https://github.com/jscraftcamp/website/blob/main/participants/\_template.json](https://jscraftcamp.org/register/) and contains the mandatory fields like `name`, `when`, `whatIsMyConnectionToJavascript` and `whatCanIContribute`
- [x] If I can NOT attend, I will either send another pull request removing my JSON file or an e-mail with the subject 'UNREGISTER' to team@jscraftcamp.org
- [x] I agree that the data I enter in the registration can be used for running the event, e.g. make a name tag, count me as participant. I acknowledge that my data are public on GitHub and I agree that I will be listed on the JSCraftCamp website as a participant.
- [x] I agree that photos and videos might be taken and published (e.g. on social media) during the event.
- [x] I understand that I might NOT get a T-Shirt, because they might be in production already
- [x] I asked my company about sponsoring (see open items at: https://github.com/orgs/jscraftcamp/projects/5/views/1)

Are you from a sponsoring company?

- [x] Yes, I am from company inovex
