### PR TITLE
Create hansamann.json

### DIFF
--- a/participants/hansamann.json
+++ b/participants/hansamann.json
@@ -1,0 +1,39 @@
+
+{
+	// your name / nickname (required)
+	"name": "Sven Haiges",
+	// optional company name (required)
+	"company": "SAP",
+	// either both days or at least one day has to be set to true
+	"when": {
+		// 2023-06-30
+		"friday": true,
+		// 2023-07-01
+		"saturday": false
+	},
+	// if you are willing to take session notes and publish them to github (required)
+	"iCanTakeNotesDuringSessions": false,
+	// your current interests (JS and in general) (required)
+	"tags": ["Svelte", "Zustand", "JS"],
+	// if you only eat vegan food (optional)
+	"vegan": false,
+	// if you only eat vegan or vegetarian food (optional)
+	"vegetarian": true,
+	// what you cannot eat or drink (optional)
+	"allergies": [],
+	// tell us a few words how JavaScript affects you (required)
+	"whatIsMyConnectionToJavascript": "used for work and fun",
+	// what can you contribute to the bar camp (required)
+	"whatCanIContribute": "create a POAP, chat about svelte",
+	// if you want a T-Shirt we need your size and variant preference (optional)
+	"tShirt": {
+		// S | M | L | XL | 2XL | 3XL
+		"size": "L",
+		// fitted (also known as waist cut or women variant) or regular
+		"type": "regular"
+	},
+	// your Mastodon URL (optional)
+	"mastodon": "https://mastodon.social/@hansamann",
+	// your website URL or other social media (optional)
+	"website": "https://nopants.dev"
+}


### PR DESCRIPTION
adding myself

I would like to register for JS CraftCamp.

- [ x] My pull request contains a JSON file `$name_or_nickname.json`
- [ x] The JSON file follows the template at [https://github.com/jscraftcamp/website/blob/main/participants/\_template.json](https://jscraftcamp.org/register/) and contains the mandatory fields like `name`, `when`, `whatIsMyConnectionToJavascript` and `whatCanIContribute`
- [x ] If I can NOT attend, I will either send another pull request removing my JSON file or an e-mail with the subject 'UNREGISTER' to team@jscraftcamp.org
- [x] I agree that the data I enter in the registration can be used for running the event, e.g. make a name tag, count me as participant. I acknowledge that my data are public on GitHub and I agree that I will be listed on the JSCraftCamp website as a participant.
- [x ] I agree that photos and videos might be taken and published (e.g. on social media) during the event.
- [x ] I understand that I might NOT get a T-Shirt, because they might be in production already
- [ ] I asked my company about sponsoring (see open items at: https://github.com/orgs/jscraftcamp/projects/5/views/1)

Are you from a sponsoring company?

- [ ] Yes, I am from company ?????
