### PR TITLE
add participants/jfhr.json

### DIFF
--- a/participants/jfhr.json
+++ b/participants/jfhr.json
@@ -1,0 +1,19 @@
+{
+	"name": "Jakob Fahr",
+	"company": "InsiderPie",
+	"when": {
+		"friday": true,
+		"saturday": true
+	},
+	"iCanTakeNotesDuringSessions": false,
+	"tags": ["TypeScript", "JavaScript", "Node.JS", "Web", "Scraping", "Svelte"],
+	"vegan": true,
+	"vegetarian": true,
+	"whatIsMyConnectionToJavascript": "I've been using JavaScript and TypeScript for a few years, and also started a software company that uses 97% JavaScript. The best thing about JS for me is: it lets me do what I want relatively easily, it's easy to read, and I can use the same language throughout the stack.",
+	"whatCanIContribute": "I can share my experience gathering data from APIs, websites, RSS feeds, PDF files, E-Mails, and other sources across the web.",
+	"tShirt": {
+		"size": "S",
+		"type": "regular"
+	},
+	"website": "https://jfhr.de"
+}


### PR DESCRIPTION
I would like to register for JS CraftCamp.

- [x] My pull request contains a JSON file `$name_or_nickname.json`
- [x] The JSON file follows the template at [https://github.com/jscraftcamp/website/blob/main/participants/\_template.json](https://jscraftcamp.org/register/) and contains the mandatory fields like `name`, `when`, `whatIsMyConnectionToJavascript` and `whatCanIContribute`
- [x] If I can NOT attend, I will either send another pull request removing my JSON file or an e-mail with the subject 'UNREGISTER' to team@jscraftcamp.org
- [x] I agree that the data I enter in the registration can be used for running the event, e.g. make a name tag, count me as participant. I acknowledge that my data are public on GitHub and I agree that I will be listed on the JSCraftCamp website as a participant.
- [x] I agree that photos and videos might be taken and published (e.g. on social media) during the event.
- [x] I understand that I might NOT get a T-Shirt, because they might be in production already
- [x] I asked my company about sponsoring (see open items at: https://github.com/orgs/jscraftcamp/projects/5/views/1)

Are you from a sponsoring company?

- [ ] Yes, I am from company ?????
