### PR TITLE
register ahmad soliman into participants folder

### DIFF
--- a/participants/ahmad_soliman.json
+++ b/participants/ahmad_soliman.json
@@ -1,0 +1,21 @@
+{
+	"name": "Ahmad Soliman",
+	"company": "Toptal",
+	"when": {
+		"friday": true,
+		"saturday": true
+	},
+	"iCanTakeNotesDuringSessions": false,
+	"tags": ["Next.Js", "React", "Typescript", "Angular", "Tailwind"],
+	"vegan": false,
+	"vegetarian": false,
+	"allergies": [],
+	"whatIsMyConnectionToJavascript": "As a frontend developer, Javascript affects my everyday life and occupies a huge space of my mental space.",
+	"whatCanIContribute": "Sharing my knowledge around frontend frameworks and specifics of React, NextJs, Angular.",
+	"tShirt": {
+		"size": "2XL",
+		"type": "regular"
+	},
+	"twitter": "ElDoc92",
+	"website": "https://www.toptal.com/resume/ahmad-soliman"
+}


### PR DESCRIPTION
I would like to register for JS CraftCamp.

- [X] My pull request contains a JSON file `$name_or_nickname.json`
- [X] The JSON file follows the template at [https://github.com/jscraftcamp/website/blob/main/participants/\_template.json](https://jscraftcamp.org/register/) and contains the mandatory fields like `name`, `when`, `whatIsMyConnectionToJavascript` and `whatCanIContribute`
- [X] If I can NOT attend, I will either send another pull request removing my JSON file or an e-mail with the subject 'UNREGISTER' to team@jscraftcamp.org
- [X] I agree that the data I enter in the registration can be used for running the event, e.g. make a name tag, count me as participant. I acknowledge that my data are public on GitHub and I agree that I will be listed on the JSCraftCamp website as a participant.
- [X] I agree that photos and videos might be taken and published (e.g. on social media) during the event.
- [X] I understand that I might NOT get a T-Shirt, because they might be in production already
- [X] I asked my company about sponsoring (see open items at: https://github.com/orgs/jscraftcamp/projects/5/views/1)

Are you from a sponsoring company?

- [X] No
