### PR TITLE
fix(Participants): fix accidental content overflow

### DIFF
--- a/src/lib/participants/Participant.svelte
+++ b/src/lib/participants/Participant.svelte
@@ -135,6 +135,9 @@
 	}
 	.details {
 		flex: 1;
+        word-wrap: break-word;
+        white-space: pre-wrap;
+        word-break: break-word;
 	}
 	.details h4 {
 		margin-top: 1em;


### PR DESCRIPTION
I would like to supply a small fix, as my contents on the detail page do not wrap nicely.

Sorry for the hassle, a local fork of an old version of the website had some non pushed commits ...