### PR TITLE
feat(participants): add celestine

### DIFF
--- a/participants/celestine_auburger.json
+++ b/participants/celestine_auburger.json
@@ -1,0 +1,36 @@
+{
+    // required
+    "name": "Celestine Auburger",
+    // optional
+    "company": "Peerigon GmbH",
+    // required
+    "when": {
+        "friday": true,
+        "saturday": true
+    },
+    // required
+    "iCanTakeNotesDuringSessions": false,
+    // required - at least one
+    "tags": ["Typescript", "React", "Vue", "GraphQL","Playwright"],
+    // optional
+    "vegan": false,
+    // optional
+    "vegetarian": false,
+    // optional
+    "allergies": [],
+    // required
+    "whatIsMyConnectionToJavascript": "I use it everyday, but it's Typescript now!",
+    // required
+    "whatCanIContribute": "Good coffee and a nice chat!",
+    // optional
+    "tShirt": {
+        "size": "L",
+        "type": "fitted"
+    },
+    // optional
+    "twitter": null,
+    // optional
+    "mastodon": null,
+    // optional
+    "website": null
+}


### PR DESCRIPTION
I would like to register for JS CraftCamp.

- [x] My pull request contains a JSON file `$name_or_nickname.json`
- [ ] The JSON file follows the template at [https://github.com/jscraftcamp/website/blob/main/participants/\_template.json](https://jscraftcamp.org/register/) and contains the mandatory fields like `name`, `when`, `whatIsMyConnectionToJavascript` and `whatCanIContribute`
- [ ] If I can NOT attend, I will either send another pull request removing my JSON file or an e-mail with the subject 'UNREGISTER' to team@jscraftcamp.org
- [ ] I agree that the data I enter in the registration can be used for running the event, e.g. make a name tag, count me as participant. I acknowledge that my data are public on GitHub and I agree that I will be listed on the JSCraftCamp website as a participant.
- [ ] I agree that photos and videos might be taken and published (e.g. on social media) during the event.
- [ ] I understand that I might NOT get a T-Shirt, because they might be in production already
- [ ] I asked my company about sponsoring (see open items at: https://github.com/orgs/jscraftcamp/projects/5/views/1)

Are you from a sponsoring company?

- [ ] Yes, I am from company ?????
