### PR TITLE
Add David Leitner as Participant

### DIFF
--- a/participants/david_leitner.json
+++ b/participants/david_leitner.json
@@ -1,0 +1,21 @@
+{
+    "name": "David Leitner",
+    "company": "SQUER Solutions",
+    "when": {
+        "friday": true,
+        "saturday": false
+    },
+    "iCanTakeNotesDuringSessions": false,
+    "tags": ["React", "Svelte", "Solid", "Next", "GraphQL"],
+    "vegan": false,
+    "vegetarian": false,
+    "whatIsMyConnectionToJavascript": "Engineer",
+    "whatCanIContribute": "I talk about the state of MicroFrontends",
+    "tShirt": {
+        "size": "L",
+        "type": "regular"
+    },
+    "twitter": "@duffleit",
+    "mastodon": "@duffleit@mastodon.social",
+    "website": "https://leitner.io"
+}


### PR DESCRIPTION
I would like to register for JS CraftCamp.

- [x] My pull request contains a JSON file `$name_or_nickname.json`
- [x] The JSON file follows the template at [https://github.com/jscraftcamp/website/blob/main/participants/\_template.json](https://jscraftcamp.org/register/) and contains the mandatory fields like `name`, `when`, `whatIsMyConnectionToJavascript` and `whatCanIContribute`
- [x] If I can NOT attend, I will either send another pull request removing my JSON file or an e-mail with the subject 'UNREGISTER' to team@jscraftcamp.org
- [x] I agree that the data I enter in the registration can be used for running the event, e.g. make a name tag, count me as participant. I acknowledge that my data are public on GitHub and I agree that I will be listed on the JSCraftCamp website as a participant.
- [x] I agree that photos and videos might be taken and published (e.g. on social media) during the event.
- [x] I understand that I might NOT get a T-Shirt, because they might be in production already
- [x] I asked my company about sponsoring (see open items at: https://github.com/orgs/jscraftcamp/projects/5/views/1)
