### PR TITLE
fix: add linkedin as a valid social network

### DIFF
--- a/src/lib/participants/Participant.svelte
+++ b/src/lib/participants/Participant.svelte
@@ -13,7 +13,8 @@
 	export let isActive: boolean = false;
 
 	let isShowingDetails = false;
-	const hasSocialLink = participant.X || participant.mastodon || participant.website;
+	const hasSocialLink =
+		participant.X || participant.mastodon || participant.website || participant.linkedin;
 
 	const dispatch = createEventDispatcher<{ selectedTag: string }>();
 </script>


### PR DESCRIPTION
While checking my registration, I noticed that social media buttons are not displayed if the only social media is linkedin. This PR fixes that. 