### PR TITLE
Add marvin hagemeister to participants

### DIFF
--- a/participants/marvinh.json
+++ b/participants/marvinh.json
@@ -1,0 +1,25 @@
+{
+	"realName": {
+		"givenName": "Marvin",
+		"familyName": "Hagemeister",
+		"placeFamilyNameFirst": false,
+		"hideFamilyNameOnWebsite": false
+	},
+	"githubAccountName": "marvinhagemeister",
+	"company": "Deno",
+	"when": {
+		"friday": true,
+		"saturday": false
+	},
+	"iCanTakeNotesDuringSessions": false,
+	"tags": ["Deno", "Fresh", "TypeScript", "Rust", "Web APIs", "Preact"],
+	"vegan": false,
+	"vegetarian": false,
+	"whatIsMyConnectionToJavascript": "Working at Deno and on Preact",
+	"whatCanIContribute": "Can share stories about working on Preact, code golfing, optimizing JS tools, Signals, etc",
+	"tShirtSize": "M",
+	"mastodon": "https://infosec.exchange/@marvinh",
+	"linkedin": "https://de.linkedin.com/in/marvin-hagemeister-53758b204",
+	"X": "marvinhagemeist",
+	"website": "https://marvinh.dev/"
+}


### PR DESCRIPTION
I would like to register for JS CraftCamp.

- [x] My pull request contains a JSON file `$name_or_nickname.json`
- [x] I read the `THE IMPORTANT STUFF` at [https://jscraftcamp.org/registration](https://jscraftcamp.org/registration), the JSON file follows the [template](https://github.com/jscraftcamp/website/blob/main/participants/_template.json), and contains the mandatory fields like `realName`, `githubAccountName`, `when`, `iCanTakeNotesDuringSessions`, `whatIsMyConnectionToJavascript` and `whatCanIContribute`.
- [x] If I can NOT attend, I will either send another pull request removing my JSON file or an e-mail with the subject 'UNREGISTER' to team@jscraftcamp.org
- [x] I agree that the data I enter in the registration can be used for running the event, e.g. make a name tag, count me as participant. I acknowledge that my data are public on GitHub and I agree that I will be listed on the JSCraftCamp website as a participant.
- [x] I agree that photos and videos might be taken and published (e.g. on social media) during the event.
- [x] I understand that I might NOT get a T-Shirt, because they might be in production already
- [x] I asked my company about sponsoring (see open items at: https://github.com/orgs/jscraftcamp/projects/5/views/1)

Are you from a sponsoring company?

- [x] Yes, I am from company Deno
