### PR TITLE
Fix: Participant Card Logo overflows when 5+ links are present

### DIFF
--- a/src/lib/participants/Participant.svelte
+++ b/src/lib/participants/Participant.svelte
@@ -165,6 +165,7 @@
 	.socials {
 		align-items: center;
 		display: flex;
+		flex-wrap: wrap;
 		margin: 0 -0.5em -0.5em;
 	}
 	.socials img {


### PR DESCRIPTION
This pull request fixes an issue where a participant's card overflows if it has 5 or more social media logos displayed.

**Fix:**
Added flex-wrap: wrap; on the div with class 'socials'.

<img width="447" alt="Screenshot 2024-04-22 at 15 28 23" src="https://github.com/jscraftcamp/website/assets/161830919/eaf0449d-1e7e-42eb-b6ee-6d3144c96d53">
