### PR TITLE
Add matthew_odonnell.json

### DIFF
--- a/participants/matthew_odonnell.json
+++ b/participants/matthew_odonnell.json
@@ -1,0 +1,21 @@
+{
+	"realName": {
+		"givenName": "Matthew",
+		"familyName": "O'Donnell"
+	},
+	"githubAccountName": "mjodonnell",
+	"company": "New Coder/Career Changer",
+	"when": {
+		"friday": true,
+		"saturday": true
+	},
+	"iCanTakeNotesDuringSessions": false,
+	"tags": ["React", "Pixi.js", "TypeScript", "Vue.js"],
+	"vegan": false,
+	"vegetarian": false,
+	"whatIsMyConnectionToJavascript": "New coder. Want to gain first experience/job using JavaScript",
+	"whatCanIContribute": "Can support organizing team at event. Willing to conduct outreach to potential speakers/participants",
+	"tShirtSize": "XXL",
+	"linkedin": "https://www.linkedin.com/in/mjodonnell/",
+	"X": "mjodonnell",
+}


### PR DESCRIPTION
I would like to register for JS CraftCamp.

- [x] My pull request contains a JSON file `$name_or_nickname.json`
- [x] I read the `THE IMPORTANT STUFF` at [https://jscraftcamp.org/registration](https://jscraftcamp.org/registration), the JSON file follows the [template](https://github.com/jscraftcamp/website/blob/main/participants/_template.json), and contains the mandatory fields like `realName`, `githubAccountName`, `when`, `iCanTakeNotesDuringSessions`, `whatIsMyConnectionToJavascript` and `whatCanIContribute`.
- [x] If I can NOT attend, I will either send another pull request removing my JSON file or an e-mail with the subject 'UNREGISTER' to team@jscraftcamp.org
- [x] I agree that the data I enter in the registration can be used for running the event, e.g. make a name tag, count me as participant. I acknowledge that my data are public on GitHub and I agree that I will be listed on the JSCraftCamp website as a participant.
- [x] I agree that photos and videos might be taken and published (e.g. on social media) during the event.
- [x] I understand that I might NOT get a T-Shirt, because they might be in production already
- [x] I asked my company about sponsoring (see open items at: https://github.com/orgs/jscraftcamp/projects/5/views/1)

Are you from a sponsoring company?

- [ ] Yes, I am from company ?????
