### PR TITLE
Relax minLength name constraints

### DIFF
--- a/static/schemas/participants.2024.json
+++ b/static/schemas/participants.2024.json
@@ -7,8 +7,8 @@
 				"realName": {
 					"type": "object",
 					"properties": {
-						"givenName": { "type": "string", "minLength": 2, "maxLength": 100 },
-						"familyName": { "type": "string", "minLength": 2, "maxLength": 100 },
+						"givenName": { "type": "string", "minLength": 0, "maxLength": 100 },
+						"familyName": { "type": "string", "minLength": 1, "maxLength": 100 },
 						"placeFamilyNameFirst": { "type": ["boolean", "null"] },
 						"hideFamilyNameOnWebsite": { "type": ["boolean", "null"] }
 					},


### PR DESCRIPTION
Funnily, as far as I can tell, this didn't even make patio11's list of falsehoods programmers believe about names. Still, names being at least two characters long is surely one of them. If we're sticking with the existing schema, relaxing it to a non-zero family name seems like the best we can do.