### PR TITLE
fix: Disallow empty strings in tags

### DIFF
--- a/src/lib/participants/participant-schema.ts
+++ b/src/lib/participants/participant-schema.ts
@@ -10,7 +10,8 @@ const optionalBoolean = (defaultValue = false) =>
 		.nullish()
 		.transform((v) => v ?? defaultValue);
 
-const nonEmptyStringArray = (errorMessage?: string) => z.string().array().nonempty(errorMessage);
+const nonEmptyStringArray = (errorMessage?: string) =>
+	z.string().nonempty().array().nonempty(errorMessage);
 
 /**
  * preprocessing function which replaces empty strings ('') or empty arrays ([]) with null


### PR DESCRIPTION
We currently allow empty strings in the list of tags. This should not be possible: The tag list should only contain non-empty strings.

Be aware, this will break the PR / registration for #1941 (@IObert)