### PR TITLE
chore: register Gustaf as a participant

### DIFF
--- a/participants/gustaf.json
+++ b/participants/gustaf.json
@@ -1,0 +1,34 @@
+{
+  "realName": {
+    "givenName": "Gustaf",
+    "familyName": "Graf",
+    "placeFamilyNameFirst": false,
+    "hideFamilyNameOnWebsite": false
+  },
+  "githubAccountName": "gggscript",
+  "company": "onyo",
+  "when": {
+    "friday": true,
+    "saturday": false
+  },
+  "iCanTakeNotesDuringSessions": false,
+  "tags": [
+    "TypeScript",
+    "Node.js",
+    "Reverse Engineering",
+    "Scraping",
+    "Automation",
+    "Fingerprinting",
+    "Code Transforms",
+    "Error Handling",
+    "Stacktraces",
+    "Rock climbing",
+    "Rationality"
+  ],
+  "vegan": false,
+  "vegetarian": true,
+  "allergies": [],
+  "whatIsMyConnectionToJavascript": "6 years of hobby development and now a year on my job",
+  "whatCanIContribute": "I don't plan on presenting, but that's what I said last time and then I did anyway. I am still happy to talk about anything relating to the web",
+  "tShirtSize": "S"
+}


### PR DESCRIPTION
I would like to register for JS CraftCamp.

- [x] My pull request contains a JSON file `$name_or_nickname.json`
- [x] I read the `THE IMPORTANT STUFF` at [https://jscraftcamp.org/registration](https://jscraftcamp.org/registration), the JSON file follows the [template](https://github.com/jscraftcamp/website/blob/main/participants/_template.json), and contains the mandatory fields like `realName`, `githubAccountName`, `when`, `iCanTakeNotesDuringSessions`, `whatIsMyConnectionToJavascript` and `whatCanIContribute`.
- [x] If I can NOT attend, I will either send another pull request removing my JSON file or an e-mail with the subject 'UNREGISTER' to team@jscraftcamp.org
- [x] I agree that the data I enter in the registration can be used for running the event, e.g. make a name tag, count me as participant. I acknowledge that my data are public on GitHub and I agree that I will be listed on the JSCraftCamp website as a participant.
- [x] I agree that photos and videos might be taken and published (e.g. on social media) during the event.
- [x] I understand that I might NOT get a T-Shirt, because they might be in production already
- [ ] I asked my company about sponsoring (see open items at: https://github.com/orgs/jscraftcamp/projects/5/views/1)

Are you from a sponsoring company?

- [ ] Yes, I am from company ?????
