### PR TITLE
Add participant file

### DIFF
--- a/participants/jesusreal.json
+++ b/participants/jesusreal.json
@@ -26,7 +26,7 @@
 	"iCanTakeNotesDuringSessions": false,
   "tShirtSize": "L",
 	// your current interests (JS and in general) (required)
-	"tags": ["JavaScript", "Typescript", "Angular", "Browser Native APIs", "AI", "SSG", "SSR", "Micro Frontends", "Leadership", "Team dynamics", "People Management"],
+	"tags": ["JavaScript", "Angular", "Browser Native APIs", "AI", "SSG", "SSR", "Micro Frontends", "Leadership", "Team dynamics", "People Management"],
 	// if you only eat vegan food (optional)
 	"vegan": false,
 	// if you only eat vegan or vegetarian food (optional)

--- a/participants/jesusreal.json
+++ b/participants/jesusreal.json
@@ -26,7 +26,7 @@
 	"iCanTakeNotesDuringSessions": false,
   "tShirtSize": "L",
 	// your current interests (JS and in general) (required)
-	"tags": ["JavaScript", "Typescript", "Angular", "Browser Native APIs", "AI", "SSG", "SSR", "Micro Frontends"],
+	"tags": ["JavaScript", "Typescript", "Angular", "Browser Native APIs", "AI", "SSG", "SSR", "Micro Frontends", "Leadership", "Team dynamics", "People Management"],
 	// if you only eat vegan food (optional)
 	"vegan": false,
 	// if you only eat vegan or vegetarian food (optional)

--- a/participants/jesusreal.json
+++ b/participants/jesusreal.json
@@ -1,0 +1,40 @@
+// vim: ft=jsonc
+// Please provide your info in your own .json file.
+// See https://jscraftcamp.org/registration for more information
+{
+	// your real name (required by location host)
+	"realName": {
+		"givenName": "Jesús",
+		"familyName": "Real",
+		// if you prefer to have your family name shown first (optional)
+		"placeFamilyNameFirst": false,
+		// if you do not want to show your family name on the participant list (optional)
+		"hideFamilyNameOnWebsite": false
+	},
+	// please put in the account name of the PR creator, if you sign up somebody else
+	"githubAccountName": "jesusreal",
+	// company name (optional)
+	"company": "Satellytes",
+	// either both days or at least one day has to be set to true
+	"when": {
+		// June 7th, 2024
+		"friday": true,
+		// June 8th, 2024
+		"saturday": true
+	},
+	// if you are willing to take session notes and publish them to github (required)
+	"iCanTakeNotesDuringSessions": false,
+  "tShirtSize": "L",
+	// your current interests (JS and in general) (required)
+	"tags": ["JavaScript", "Typescript", "Angular", "Browser Native APIs", "AI", "SSG", "SSR", "Micro Frontends"],
+	// if you only eat vegan food (optional)
+	"vegan": false,
+	// if you only eat vegan or vegetarian food (optional)
+	"vegetarian": false,
+	// tell us a few words how JavaScript affects you (required)
+	"whatIsMyConnectionToJavascript": "10+ years working as an enterprise developer",
+	// what can you contribute to the bar camp (required)
+	"whatCanIContribute": "I can share my experience in both Software Development and Soft Skills areas",
+	// your LinkedIn profile URL
+	"linkedin": "https://www.linkedin.com/in/jesusrealserrano"
+}


### PR DESCRIPTION
I would like to register for JS CraftCamp.

- [x] My pull request contains a JSON file `$name_or_nickname.json`
- [x] I read the `THE IMPORTANT STUFF` at [https://jscraftcamp.org/registration](https://jscraftcamp.org/registration), the JSON file follows the [template](https://github.com/jscraftcamp/website/blob/main/participants/_template.json), and contains the mandatory fields like `realName`, `githubAccountName`, `when`, `iCanTakeNotesDuringSessions`, `whatIsMyConnectionToJavascript` and `whatCanIContribute`.
- [x] If I can NOT attend, I will either send another pull request removing my JSON file or an e-mail with the subject 'UNREGISTER' to team@jscraftcamp.org
- [x] I agree that the data I enter in the registration can be used for running the event, e.g. make a name tag, count me as participant. I acknowledge that my data are public on GitHub and I agree that I will be listed on the JSCraftCamp website as a participant.
- [x] I agree that photos and videos might be taken and published (e.g. on social media) during the event.
- [x] I understand that I might NOT get a T-Shirt, because they might be in production already
- [ ] I asked my company about sponsoring (see open items at: https://github.com/orgs/jscraftcamp/projects/5/views/1)

Are you from a sponsoring company?

- [x] Yes, I am from company Satellytes