### PR TITLE
Create msh.json

### DIFF
--- a/participants/msh.json
+++ b/participants/msh.json
@@ -1,0 +1,52 @@
+// vim: ft=jsonc
+// Please provide your info in your own .json file.
+// See https://jscraftcamp.org/registration for more information
+{
+	// your real name (required by location host)
+	"realName": {
+		"givenName": "Maria",
+		"familyName": "Shalnova-Weinzierl",
+		// if you prefer to have your family name shown first (optional)
+		"placeFamilyNameFirst": false,
+		// if you do not want to show your family name on the participant list (optional)
+		"hideFamilyNameOnWebsite": false
+	},
+	// please put in the account name of the PR creator, if you sign up somebody else
+	"githubAccountName": "msh707",
+	// company name (optional)
+	"company": "ZDI",
+	// either both days or at least one day has to be set to true
+	"when": {
+		// June 7th, 2024
+		"friday": false,
+		// June 8th, 2024
+		"saturday": true
+	},
+	// if you are willing to take session notes and publish them to github (required)
+	"iCanTakeNotesDuringSessions": true,
+	// your current interests (JS and in general) (required)
+	"tags": ["TypeScript", "APi-Testing", "GraphQL", "Playwright", "K6", "BrowserStack"],
+	// if you only eat vegan food (optional)
+	"vegan": false,
+	// if you only eat vegan or vegetarian food (optional)
+	"vegetarian": false,
+	// what you cannot eat or drink (optional); If you don't want to put it in here, message the organizers.
+	// IMPORTANT: we cannot guarantee that food for every diet will be available,
+	//            if you have gluten free diet, please make backup plans.
+	"allergies": ["none"],
+	// tell us a few words how JavaScript affects you (required)
+	"whatIsMyConnectionToJavascript": "In my daily life I'am using TypeScript and JavaScript",
+	// what can you contribute to the bar camp (required)
+	"whatCanIContribute": "listening, participating discussions, workshops, sharing experiences in API- and UI-Testautomation",
+	// if you want a T-Shirt we need your size and variant preference (optional)
+	// the following sizes are available: S, M, L, XL, 2XL, 3XL (only regular cut)
+	"tShirtSize": "S",
+	// your Mastodon URL (optional)
+	// "mastodon": "https://mastodontech.de/@yourhandle",
+	// your LinkedIn profile URL
+	"linkedin": "https://www.linkedin.com/in/maria-shalnova-weinzierl-78b9a92/",
+	// your X (Twitter) handle - must match regex ^[a-zA-Z_]{1}[a-zA-Z0-9_]{0,14}$ (optional)
+	"X": "Maria77939067",
+	// your website URL or other social media (optional)
+	// "website": "https://www.your-domain.com"
+}


### PR DESCRIPTION
add participant msh

I would like to register for JS CraftCamp.

- [x] My pull request contains a JSON file `msh.json`
- [ x] I read the `THE IMPORTANT STUFF` at [https://jscraftcamp.org/registration](https://jscraftcamp.org/registration), the JSON file follows the [template](https://github.com/jscraftcamp/website/blob/main/participants/_template.json), and contains the mandatory fields like `realName`, `githubAccountName`, `when`, `iCanTakeNotesDuringSessions`, `whatIsMyConnectionToJavascript` and `whatCanIContribute`.
- [x ] If I can NOT attend, I will either send another pull request removing my JSON file or an e-mail with the subject 'UNREGISTER' to team@jscraftcamp.org
- [ x] I agree that the data I enter in the registration can be used for running the event, e.g. make a name tag, count me as participant. I acknowledge that my data are public on GitHub and I agree that I will be listed on the JSCraftCamp website as a participant.
- [ x] I agree that photos and videos might be taken and published (e.g. on social media) during the event.
- [ x] I understand that I might NOT get a T-Shirt, because they might be in production already
- [x ] I asked my company about sponsoring (see open items at: https://github.com/orgs/jscraftcamp/projects/5/views/1)

Are you from a sponsoring company?

- [ ] Yes, I am from company ?????
