### PR TITLE
Change name for TNG sponsoring

### DIFF
--- a/src/lib/sponsoring/sponsors-2024/is-sponsor.ts
+++ b/src/lib/sponsoring/sponsors-2024/is-sponsor.ts
@@ -13,6 +13,6 @@ export const isSponsor = (key: string) =>
 		'saab',
 		'satellytes',
 		'tiffinger-thiel',
-		'tng',
+		'tng-technology-consulting',
 		'twilio'
 	].includes(key);


### PR DESCRIPTION
We had this in the stats:
![image](https://github.com/jscraftcamp/website/assets/1767865/3be1755f-f509-429c-ac6a-c3f1aeb54a77)

...and we want this:
![image](https://github.com/jscraftcamp/website/assets/1767865/e2a7b1d0-77a5-4c5f-95f3-b1979930b5f7)
