### PR TITLE
fix: Update Logo.svelte to display correct year

### DIFF
--- a/src/lib/layout/Logo.svelte
+++ b/src/lib/layout/Logo.svelte
@@ -141,7 +141,7 @@
 			</g>
 			<g class="year-2016">
 				<path class="back" d="M109 343L107 303L147 323L149 363L109 343Z" fill="#9b03a6" />
-				<text fill="#fff" x="111" y="330">2016</text>
+				<text fill="#fff" x="111" y="330">2024</text>
 				<path class="front" d="M109 343L107 303L147 323L149 363L109 343Z" fill="#E98B23" />
 			</g>
 		</g>


### PR DESCRIPTION
I just noticed this strange copy & paste behavior that adds the string "2016". I thought we can, at least, update it to 2024 😁


https://github.com/jscraftcamp/website/assets/1873245/6a4cd93e-ef89-402a-8008-c4d783a300f9

