### PR TITLE
add participant

### DIFF
--- a/participants/mstingl.json
+++ b/participants/mstingl.json
@@ -12,7 +12,7 @@
 		"saturday": true
 	},
 	"iCanTakeNotesDuringSessions": false,
-	"tags": ["GitLab", "CI/CD", "k8s", "Rest", "Next.js", "Python"],
+	"tags": ["GitLab", "CI/CD", "k8s", "Rest", "Next.js", "PostgreSQL", "Python"],
 	"vegan": false,
 	"vegetarian": false,
 	"whatIsMyConnectionToJavascript": "I started with JS when jQuery was a thing.",

--- a/participants/mstingl.json
+++ b/participants/mstingl.json
@@ -1,0 +1,22 @@
+{
+	"realName": {
+		"givenName": "Manuel",
+		"familyName": "Stingl",
+		"placeFamilyNameFirst": false,
+		"hideFamilyNameOnWebsite": false
+	},
+	"githubAccountName": "mstingl",
+	"company": "Voltane",
+	"when": {
+		"friday": true,
+		"saturday": true
+	},
+	"iCanTakeNotesDuringSessions": false,
+	"tags": ["GitLab", "CI/CD", "k8s", "Rest", "Next.js", "Python"],
+	"vegan": false,
+	"vegetarian": false,
+	"whatIsMyConnectionToJavascript": "I started with JS when jQuery was a thing.",
+	"whatCanIContribute": "Provide insights beyond the frontend perspective.",
+	"tShirtSize": "M",
+	"website": "https://manuel.stingl.st"
+}


### PR DESCRIPTION
I would like to register for JS CraftCamp.

- [x] My pull request contains a JSON file `$name_or_nickname.json`
- [x] I read the `THE IMPORTANT STUFF` at [https://jscraftcamp.org/registration](https://jscraftcamp.org/registration), the JSON file follows the [template](https://github.com/jscraftcamp/website/blob/main/participants/_template.json), and contains the mandatory fields like `realName`, `githubAccountName`, `when`, `iCanTakeNotesDuringSessions`, `whatIsMyConnectionToJavascript` and `whatCanIContribute`.
- [x] If I can NOT attend, I will either send another pull request removing my JSON file or an e-mail with the subject 'UNREGISTER' to team@jscraftcamp.org
- [x] I agree that the data I enter in the registration can be used for running the event, e.g. make a name tag, count me as participant. I acknowledge that my data are public on GitHub and I agree that I will be listed on the JSCraftCamp website as a participant.
- [x] I agree that photos and videos might be taken and published (e.g. on social media) during the event.
- [x] I understand that I might NOT get a T-Shirt, because they might be in production already
- [x] I asked my company about sponsoring (see open items at: https://github.com/orgs/jscraftcamp/projects/7)

Are you from a sponsoring company?

- [ ] Yes, I am from company ?????
