### PR TITLE
Revert "fix: Update Logo.svelte to display correct year"

### DIFF
--- a/src/lib/layout/Logo.svelte
+++ b/src/lib/layout/Logo.svelte
@@ -141,7 +141,7 @@
 			</g>
 			<g class="year-2016">
 				<path class="back" d="M109 343L107 303L147 323L149 363L109 343Z" fill="#9b03a6" />
-				<text fill="#fff" x="111" y="330">2024</text>
+				<text fill="#fff" x="111" y="330">2016</text>
 				<path class="front" d="M109 343L107 303L147 323L149 363L109 343Z" fill="#E98B23" />
 			</g>
 		</g>


### PR DESCRIPTION
Reverts jscraftcamp/website#2014

Try hovering over the different colors of the main logo. The text that was changed actually shows the previous years. We need to fix this in a different way or the orange color will be incorrectly set to 2024.


https://github.com/jscraftcamp/website/assets/1767865/205a016c-279d-4640-832d-d82bb711ac94
