### PR TITLE
Add Gabriel as a participant

### DIFF
--- a/participants/gabriel-b.json
+++ b/participants/gabriel-b.json
@@ -1,0 +1,24 @@
+{
+	"realName": {
+		"givenName": "Gabriel",
+		"familyName": "Birke",
+		"placeFamilyNameFirst": false,
+		"hideFamilyNameOnWebsite": false
+	},
+	"githubAccountName": "gbirke",
+	"company": "Wikimedia Deutschland e.V.",
+	"when": {
+		"friday": true,
+		"saturday": true
+	},
+	"iCanTakeNotesDuringSessions": true,
+	"tags": ["Vue", "TypeScript", "TDD", "Architecture", "Web Components"],
+	"vegan": true,
+	"vegetarian": true,
+	"whatIsMyConnectionToJavascript": "Developing for the web since 1998 in various languages, I consider myself a full-stack developer",
+	"whatCanIContribute": "Vue knowledge, Non-Violent Communication (NVC), Hexagonal Architecture",
+	"tShirtSize": "L",
+	"mastodon": "https://chaos.social/@chiborg",
+	"website": "https://lebenplusplus.de/"
+}
+


### PR DESCRIPTION
I would like to register for JS CraftCamp.

- [X] My pull request contains a JSON file `$name_or_nickname.json`
- [X] I read the `THE IMPORTANT STUFF` at [https://jscraftcamp.org/registration](https://jscraftcamp.org/registration), the JSON file follows the [template](https://github.com/jscraftcamp/website/blob/main/participants/_template.json), and contains the mandatory fields like `realName`, `githubAccountName`, `when`, `iCanTakeNotesDuringSessions`, `whatIsMyConnectionToJavascript` and `whatCanIContribute`.
- [X] If I can NOT attend, I will either send another pull request removing my JSON file or an e-mail with the subject 'UNREGISTER' to team@jscraftcamp.org
- [X] I agree that the data I enter in the registration can be used for running the event, e.g. make a name tag, count me as participant. I acknowledge that my data are public on GitHub and I agree that I will be listed on the JSCraftCamp website as a participant.
- [X] I agree that photos and videos might be taken and published (e.g. on social media) during the event.
- [X] I understand that I might NOT get a T-Shirt, because they might be in production already
- [ ] I asked my company about sponsoring (see open items at: https://github.com/orgs/jscraftcamp/projects/7)

