### PR TITLE
Add bitcloud as a participant

### DIFF
--- a/participants/bitcloud
+++ b/participants/bitcloud
@@ -1,0 +1,21 @@
+{
+	"realName": {
+		"givenName": "Jan",
+		"familyName": "Schmidle",
+	},
+	"githubAccountName": "bitcloud",
+	"company": "Essentim GmbH",
+	"when": {
+		"friday": true,
+		"saturday": true
+	},
+	"iCanTakeNotesDuringSessions": false,
+	"tags": ["NodeJs", "TypeScript", "AWS", "Azure", "Terraform", "OPCUA"],
+	"vegan": false,
+	"vegetarian": false,
+	"whatIsMyConnectionToJavascript": "My goto tool to glue things together for years ;-)",
+	"whatCanIContribute": "Probably a talk about security again or automation or architecture or whatever ...",
+	"tShirtSize": "L",
+	"linkedin": "https://www.linkedin.com/in/jschmidle/",
+	"website": "https://www.essentim.com"
+}

--- a/participants/bitcloud.json
+++ b/participants/bitcloud.json
@@ -10,7 +10,7 @@
 		"saturday": true
 	},
 	"iCanTakeNotesDuringSessions": false,
-	"tags": ["NodeJs", "TypeScript", "AWS", "Azure", "Terraform", "OPCUA"],
+	"tags": ["NodeJs", "TypeScript", "AWS", "Azure", "Terraform", "OPCUA", "k8s", "security"],
 	"vegan": false,
 	"vegetarian": false,
 	"whatIsMyConnectionToJavascript": "My goto tool to glue things together for years ;-)",


### PR DESCRIPTION
I would like to register for JS CraftCamp.

- [x] My pull request contains a JSON file `$name_or_nickname.json`
- [x] I read the `THE IMPORTANT STUFF` at [https://jscraftcamp.org/registration](https://jscraftcamp.org/registration), the JSON file follows the [template](https://github.com/jscraftcamp/website/blob/main/participants/_template.json), and contains the mandatory fields like `realName`, `githubAccountName`, `when`, `iCanTakeNotesDuringSessions`, `whatIsMyConnectionToJavascript` and `whatCanIContribute`.
- [x] If I can NOT attend, I will either send another pull request removing my JSON file or an e-mail with the subject 'UNREGISTER' to team@jscraftcamp.org
- [x] I agree that the data I enter in the registration can be used for running the event, e.g. make a name tag, count me as participant. I acknowledge that my data are public on GitHub and I agree that I will be listed on the JSCraftCamp website as a participant.
- [x] I agree that photos and videos might be taken and published (e.g. on social media) during the event.
- [x] I understand that I might NOT get a T-Shirt, because they might be in production already
- [x] I asked my company about sponsoring (see open items at: https://github.com/orgs/jscraftcamp/projects/7)
