### PR TITLE
add participants/jfhr.json

### DIFF
--- a/participants/jfhr.json
+++ b/participants/jfhr.json
@@ -1,0 +1,23 @@
+{
+	"realName": {
+		"givenName": "Jakob",
+		"familyName": "Fahr",
+		"placeFamilyNameFirst": false,
+		"hideFamilyNameOnWebsite": false
+	},
+	"githubAccountName": "jfhr",
+	"company": "InsiderPie",
+	"when": {
+		"friday": false,
+		"saturday": true
+	},
+	"iCanTakeNotesDuringSessions": true,
+	"tags": ["node.js", "Scraping", "Security", "PostgreSQL"],
+	"vegan": true,
+	"vegetarian": true,
+	"allergies": [],
+	"whatIsMyConnectionToJavascript": "5 years of developing with JavaScript, including about 2 years at my own company.",
+	"whatCanIContribute": "I can share my experience writing full-stack web apps and scraping tools.",
+	"tShirtSize": "S",
+	"website": "https://jfhr.de"
+}


### PR DESCRIPTION
I would like to register for JS CraftCamp.

- [x] My pull request contains a JSON file `$name_or_nickname.json`
- [x] I read the `THE IMPORTANT STUFF` at [https://jscraftcamp.org/registration](https://jscraftcamp.org/registration), the JSON file follows the [template](https://github.com/jscraftcamp/website/blob/main/participants/_template.json), and contains the mandatory fields like `realName`, `githubAccountName`, `when`, `iCanTakeNotesDuringSessions`, `whatIsMyConnectionToJavascript` and `whatCanIContribute`.
- [x] If I can NOT attend, I will either send another pull request removing my JSON file or an e-mail with the subject 'UNREGISTER' to team@jscraftcamp.org
- [x] I agree that the data I enter in the registration can be used for running the event, e.g. make a name tag, count me as participant. I acknowledge that my data are public on GitHub and I agree that I will be listed on the JSCraftCamp website as a participant.
- [x] I agree that photos and videos might be taken and published (e.g. on social media) during the event.
- [x] I understand that I might NOT get a T-Shirt, because they might be in production already
- [ ] I asked my company about sponsoring (see open items at: https://github.com/orgs/jscraftcamp/projects/7)

Are you from a sponsoring company?

- [ ] Yes, I am from company ?????
