### PR TITLE
chore: Correct sponsor names / keys

### DIFF
--- a/src/lib/participants/participants.ts
+++ b/src/lib/participants/participants.ts
@@ -12,7 +12,9 @@ export const orgaMembers = [
 	{ givenName: 'Jörn', familyName: 'Bernhardt' },
 	{ givenName: 'Leo', familyName: 'Kettmeir' },
 	{ givenName: 'Philip', familyName: 'Saa' },
+	{ givenName: 'Robert', familyName: 'Hostlowsky' },
 	{ givenName: 'Sina', familyName: 'Aschenbrenner' },
+	{ givenName: 'Stefanie', familyName: 'Hasler' },
 	{ givenName: 'Wolfram', familyName: 'Kriesing' }
 ];
 

--- a/src/lib/participants/statistics.ts
+++ b/src/lib/participants/statistics.ts
@@ -64,7 +64,8 @@ export const createStatsFromParticipants = (
 			const companyAsKey = name
 				.toLocaleLowerCase()
 				.replace(/\s+(?:ag|gbr|gmbh|gmdbh)/, '')
-				.replace(/[^a-z]/g, '-');
+				.replace(/[^a-z]/g, '-')
+				.replace(/-+/g, '-');
 			companies[companyAsKey] = companies[companyAsKey] ?? {
 				name,
 				amount: 0,

--- a/src/lib/sponsoring/sponsors-2024/is-sponsor.ts
+++ b/src/lib/sponsoring/sponsors-2024/is-sponsor.ts
@@ -10,7 +10,7 @@ export const isSponsor = (key: string) =>
 		'maibornwolff',
 		'peerigon',
 		'project-lary',
-		'saab',
+		'saab-deutschland',
 		'satellytes',
 		'tiffinger-thiel',
 		'tng-technology-consulting',


### PR DESCRIPTION
Some sponsors did not have a 👑 next to their employee count in `/participants/stats`. This should fix it.