### PR TITLE
Create brigitte_jellinek.json

### DIFF
--- a/participants/brigitte_jellinek.json
+++ b/participants/brigitte_jellinek.json
@@ -1,0 +1,15 @@
+{
+  "name": "Brigitte Jellinek",
+  "company": "Salzburg University of Applied Sciences",
+  "when": {
+     "friday": true,
+     "saturday": true
+  },
+  "tags": ["Web", "Backend", "Education"],
+  "vegan": false,
+  "vegetarian": false,
+  "what_is_my_connection_to_javascript": "When I used JavaScript for the first time in a commercial project in around '96 it was a total desaster. We've come a long way since then!  Today I'm glad to teach JavaScript to my students.",
+  "what_can_i_contribute": "avid listener, participant in discussions, might bring a card game or two, help out where I can, ...",
+  "tshirt": "W-XL",
+  "twitter": "bjelline"
+}


### PR DESCRIPTION
too late

I would like to register for JS CraftCamp.

- [ ] My pull request contains a JSON file `$name_or_nickname.json`
- [ ] I read the `THE IMPORTANT STUFF` at [https://jscraftcamp.org/registration](https://jscraftcamp.org/registration), the JSON file follows the [template](https://github.com/jscraftcamp/website/blob/main/participants/_template.json), and contains the mandatory fields like `realName`, `githubAccountName`, `when`, `iCanTakeNotesDuringSessions`, `whatIsMyConnectionToJavascript` and `whatCanIContribute`.
- [ ] If I can NOT attend, I will either send another pull request removing my JSON file or an e-mail with the subject 'UNREGISTER' to team@jscraftcamp.org
- [ ] I agree that the data I enter in the registration can be used for running the event, e.g. make a name tag, count me as participant. I acknowledge that my data are public on GitHub and I agree that I will be listed on the JSCraftCamp website as a participant.
- [ ] I agree that photos and videos might be taken and published (e.g. on social media) during the event.
- [ ] I understand that I might NOT get a T-Shirt, because they might be in production already
- [ ] I asked my company about sponsoring (see open items at: https://github.com/orgs/jscraftcamp/projects/7)

Are you from a sponsoring company?

- [ ] Yes, I am from company ?????
