### PR TITLE
Fix typo in "When" box for registration

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -92,7 +92,7 @@
 			<p><strong>27. & 28. June 2025</strong></p>
 			{#if $registrationState === 'not-yet'}
 				<!-- eslint-disable-next-line svelte/no-at-html-tags -->
-				<p>Registration will open on April 30nd, 2025. {@html $countdown}</p>
+				<p>Registration will open on April 30th, 2025. {@html $countdown}</p>
 			{:else if $registrationState === 'closed'}
 				<p>
 					Registration is closed, we're full! <a href="{base}/registration">Join the wait list</a>!


### PR DESCRIPTION
The "When" part was wrong.

Current:
![image](https://github.com/user-attachments/assets/3a5e591a-261e-4991-a248-b17901120e3b)

Corrected:
![image](https://github.com/user-attachments/assets/c2221ab4-55a5-48f1-8163-8f75e8beda4c)
