### PR TITLE
fix: registration status display

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -12,7 +12,6 @@
 	import WhatToExpect from './WhatYouCanExpect.svelte';
 	import {
 		getRegistrationState,
-		registrationClosessAt,
 		registrationOpensAt,
 		timeLeft
 	} from '$lib/participants/registration';
@@ -32,10 +31,13 @@
 	const registrationState = writable<'not-yet' | 'closed' | 'open'>(getRegistrationState());
 	const updateCountdown = () => {
 		const now = +new Date();
-		if (registrationOpensAt <= now && now <= registrationClosessAt) {
-			$registrationState = 'closed';
+
+		const state = getRegistrationState();
+		if (state !== 'not-yet') {
+			$registrationState = state;
 			return;
 		}
+
 		const { days, hours, minutes, seconds } = timeLeft(now, registrationOpensAt);
 		const timeAsStringArray = [
 			days > 0 ? `${days} days` : '',


### PR DESCRIPTION
~~I would like to register for JS CraftCamp.~~

I would like to fix a display bug. Right now the home page shows:

![image](https://github.com/user-attachments/assets/5596b9c8-2a73-452a-b18b-97858c09d9e0)

But registration closes end of June. This fix will change the `updateCountdown()` effect so it no longer changes the registration status to closed before the registration actually closes.