### PR TITLE
fix: Open registration as we are not full YET

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -33,7 +33,7 @@
 	const updateCountdown = () => {
 		const now = +new Date();
 		if (registrationOpensAt <= now && now <= registrationClosessAt) {
-			$registrationState = 'closed';
+			$registrationState = 'open';
 			return;
 		}
 		const { days, hours, minutes, seconds } = timeLeft(now, registrationOpensAt);


### PR DESCRIPTION
Sorry, we made a quick fix last year to close the registration when we had too many participants registered. This PR reverts this change.