### PR TITLE
Create markus_krogemann.json

### DIFF
--- a/participants/markus_krogemann.json
+++ b/participants/markus_krogemann.json
@@ -1,0 +1,29 @@
+{
+	"realName": {
+		"givenName": "Markus",
+		"familyName": "Krogemann",
+		"placeFamilyNameFirst": false,
+		"hideFamilyNameOnWebsite": false
+	},
+	"githubAccountName": "mkrogemann",
+	"company": "Markus Krogemann",
+	"when": {
+		"friday": true,
+		"saturday": true
+	},
+	"iCanTakeNotesDuringSessions": true,
+  "tags": [
+    "TypeScript",
+    "Tailwind CSS",
+    "Astro",
+    "AWS"
+  ],
+	"vegan": false,
+	"vegetarian": false,
+  "allergies": [],
+	"whatIsMyConnectionToJavascript": "Mainly wanting to learn more about language, ecosystem and community",
+	"whatCanIContribute": "Lots of curiosity and anecdotes on failed endeavours",
+	"tShirtSize": "XL",
+	"linkedin": "https://www.linkedin.com/in/mkrogemann/",
+  "website": "https://just-cues.krogemann.de"
+}


### PR DESCRIPTION
I would like to register for JS CraftCamp.

- [ x] My pull request contains a JSON file `$name_or_nickname.json`
- [ x] I read the `THE IMPORTANT STUFF` at [https://jscraftcamp.org/registration](https://jscraftcamp.org/registration), the JSON file follows the [template](https://github.com/jscraftcamp/website/blob/main/participants/_template.json), and contains the mandatory fields like `realName`, `githubAccountName`, `when`, `iCanTakeNotesDuringSessions`, `whatIsMyConnectionToJavascript` and `whatCanIContribute`.
- [ x] If I can NOT attend, I will either send another pull request removing my JSON file or an e-mail with the subject 'UNREGISTER' to team@jscraftcamp.org
- [ x] I agree that the data I enter in the registration can be used for running the event, e.g. make a name tag, count me as participant. I acknowledge that my data are public on GitHub and I agree that I will be listed on the JSCraftCamp website as a participant.
- [ x] I agree that photos and videos might be taken and published (e.g. on social media) during the event.
- [ x] I understand that I might NOT get a T-Shirt, because they might be in production already
- [ x] I asked my company about sponsoring (see open items at: https://github.com/orgs/jscraftcamp/projects/10)

Are you from a sponsoring company?

- [ ] Yes, I am from company ?????
