### PR TITLE
Fix typo in participant description.

### DIFF
--- a/participants/oliver.json
+++ b/participants/oliver.json
@@ -39,7 +39,7 @@
   //            if you have gluten free diet, please make backup plans.
   "allergies": [],
   // tell us a few words how JavaScript affects you (required)
-  "whatIsMyConnectionToJavascript": "First contact areound 1995, still learning.",
+  "whatIsMyConnectionToJavascript": "First contact around 1995, still learning.",
   // what can you contribute to the bar camp (required)
   "whatCanIContribute": "I can try to help, wherever help is needed.",
   // if you want a T-Shirt we need your size and variant preference (optional)


### PR DESCRIPTION
**I would like to register for JS CraftCamp.**

- [x] My pull request contains a JSON file `$name_or_nickname.json`
- [x] I read the `THE IMPORTANT STUFF` at [https://jscraftcamp.org/registration](https://jscraftcamp.org/registration), the JSON file follows the [template](https://github.com/jscraftcamp/website/blob/main/participants/_template.json), and contains the mandatory fields like `realName`, `githubAccountName`, `when`, `iCanTakeNotesDuringSessions`, `whatIsMyConnectionToJavascript` and `whatCanIContribute`.
- [x] If I can NOT attend, I will either send another pull request removing my JSON file or an e-mail with the subject 'UNREGISTER' to team@jscraftcamp.org
- [x] I agree that the data I enter in the registration can be used for running the event, e.g. make a name tag, count me as participant. I acknowledge that my data are public on GitHub and I agree that I will be listed on the JSCraftCamp website as a participant.
- [x] I agree that photos and videos might be taken and published (e.g. on social media) during the event.
- [x] I understand that I might NOT get a T-Shirt, because they might be in production already
- [x] I asked my company about sponsoring (see open items at: https://github.com/orgs/jscraftcamp/projects/10)

**Are you from a sponsoring company?**

- [x] Yes, I am from company Inspired Consulting

**Optional GIF to show my level of excitement**

<!-- If you like to share some fun GIF with us, try to drag & drop something from giphy.com here ;) -->
