### PR TITLE
feat: add olesia as participant

### DIFF
--- a/participants/olesia.json
+++ b/participants/olesia.json
@@ -1,0 +1,53 @@
+// vim: ft=jsonc
+// Please provide your info in your own .json file.
+// See https://jscraftcamp.org/registration for more information
+{
+	// your real name (required by location host)
+	"realName": {
+		"givenName": "Olesia",
+		"familyName": "Shcherbenko",
+		// if you prefer to have your family name shown first (optional)
+		"placeFamilyNameFirst": false,
+		// if you do not want to show your family name on the participant list (optional)
+		"hideFamilyNameOnWebsite": false
+	},
+	// please put in the account name of the PR creator, if you sign up somebody else
+	"githubAccountName": "OlesiaShcherbenko",
+	// company name (optional)
+	"company": "Seven.One Entertainment Group",
+	// either both days or at least one day has to be set to true.
+	// If you cannot make one of the days, please set it to false, to allow someone else take that spot!
+	"when": {
+		// June 27th, 2025
+		"friday": true,
+		// June 28th, 2025
+		"saturday": true
+	},
+	// if you are willing to take session notes and publish them to github (required)
+	"iCanTakeNotesDuringSessions": false,
+	// your current interests (JS and in general) (required)
+	"tags": ["JavaScript", "TypeScript", "React", "Next.js", "Storybook", "REST API", "Design System"],
+	// if you only eat vegan food (optional)
+	"vegan": false,
+	// if you only eat vegan or vegetarian food (optional)
+	"vegetarian": false,
+	// what you cannot eat or drink (optional); If you don't want to put it in here, message the organizers.
+	// IMPORTANT: we cannot guarantee that food for every diet will be available,
+	//            if you have gluten free diet, please make backup plans.
+	"allergies": [],
+	// tell us a few words how JavaScript affects you (required)
+	"whatIsMyConnectionToJavascript": "I'm transitioning into tech and currently learning JavaScript.",
+	// what can you contribute to the bar camp (required)
+	"whatCanIContribute": "I'm happy to take photos, help organize, or support the social media team.",
+	// if you want a T-Shirt we need your size and variant preference (optional)
+	// the following sizes are available: S, M, L, XL, 2XL, 3XL (only regular cut)
+	"tShirtSize": "M",
+	// your Mastodon URL (optional)
+	"mastodon": "https://mastodontech.de/@yourhandle",
+	// your LinkedIn profile URL
+	"linkedin": "https://www.linkedin.com/in/olesia-shcherbenko-822488212/",
+	// your X (Twitter) handle - must match regex ^[a-zA-Z_]{1}[a-zA-Z0-9_]{0,14}$ (optional)
+	"X": "yourhandle",
+	// your website URL or other social media (optional)
+	"website": "https://www.your-domain.com"
+}

--- a/participants/olesia.json
+++ b/participants/olesia.json
@@ -42,12 +42,6 @@
 	// if you want a T-Shirt we need your size and variant preference (optional)
 	// the following sizes are available: S, M, L, XL, 2XL, 3XL (only regular cut)
 	"tShirtSize": "M",
-	// your Mastodon URL (optional)
-	"mastodon": "https://mastodontech.de/@yourhandle",
 	// your LinkedIn profile URL
-	"linkedin": "https://www.linkedin.com/in/olesia-shcherbenko-822488212/",
-	// your X (Twitter) handle - must match regex ^[a-zA-Z_]{1}[a-zA-Z0-9_]{0,14}$ (optional)
-	"X": "yourhandle",
-	// your website URL or other social media (optional)
-	"website": "https://www.your-domain.com"
+	"linkedin": "https://www.linkedin.com/in/olesia-shcherbenko-822488212/"
 }


### PR DESCRIPTION
**I would like to register for JS CraftCamp.**

- [x] My pull request contains a JSON file `$name_or_nickname.json`
- [x] I read the `THE IMPORTANT STUFF` at [https://jscraftcamp.org/registration](https://jscraftcamp.org/registration), the JSON file follows the [template](https://github.com/jscraftcamp/website/blob/main/participants/_template.json), and contains the mandatory fields like `realName`, `githubAccountName`, `when`, `iCanTakeNotesDuringSessions`, `whatIsMyConnectionToJavascript` and `whatCanIContribute`.
- [x] If I can NOT attend, I will either send another pull request removing my JSON file or an e-mail with the subject 'UNREGISTER' to team@jscraftcamp.org
- [x] I agree that the data I enter in the registration can be used for running the event, e.g. make a name tag, count me as participant. I acknowledge that my data are public on GitHub and I agree that I will be listed on the JSCraftCamp website as a participant.
- [x] I agree that photos and videos might be taken and published (e.g. on social media) during the event.
- [x] I understand that I might NOT get a T-Shirt, because they might be in production already
- [x] I asked my company about sponsoring (see open items at: https://github.com/orgs/jscraftcamp/projects/10)

**Are you from a sponsoring company?**
 - [ ] Yes, I am from company ?????