### PR TITLE
Improve stats and fix max seats

### DIFF
--- a/src/lib/participants/statistics.ts
+++ b/src/lib/participants/statistics.ts
@@ -27,6 +27,9 @@ export type Statistics = {
 		notetakersFriday: number;
 		notetakersSaturday: number;
 	};
+	vegan: number;
+	vegetarian: number;
+	noFoodPreference: number;
 };
 
 const isOrgaMember = (p: Name, orgaMembers: Name[]) => {
@@ -113,6 +116,18 @@ export const createStatsFromParticipants = (
 		return 1;
 	});
 	const sortedCompanies = sortedCompanyEntries.map(([, company]) => company);
+	const { vegan, vegetarian, noFoodPreference } = participants.reduce(
+		(acc, { vegan, vegetarian }) => {
+			if (vegan) {
+				return { ...acc, vegan: acc.vegan + 1 };
+			}
+			if (vegetarian) {
+				return { ...acc, vegetarian: acc.vegetarian + 1 };
+			}
+			return { ...acc, noFoodPreference: acc.noFoodPreference + 1 };
+		},
+		{ vegan: 0, vegetarian: 0, noFoodPreference: 0 }
+	);
 
 	return {
 		allergies,
@@ -121,6 +136,9 @@ export const createStatsFromParticipants = (
 		orgaShirts,
 		participantCount: participants.length,
 		participantsShirts,
-		participants: stats
+		participants: stats,
+		vegan,
+		vegetarian,
+		noFoodPreference
 	};
 };

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -100,9 +100,9 @@
 			{:else}
 				<p><a href="{base}/registration">Registration is open!</a></p>
 				<p>Grab your spot!</p>
-				<p>Friday: <strong>{100 - data.fridayParticipants}</strong> spots left</p>
+				<p>Friday: <strong>{Math.max(0, 100 - data.fridayParticipants)}</strong> spots left</p>
 				<p>
-					Saturday: <strong>{100 - data.saturdayParticipants}</strong> spots left
+					Saturday: <strong>{Math.max(0, 100 - data.saturdayParticipants)}</strong> spots left
 				</p>
 			{/if}
 		</InfoBox>

--- a/src/routes/participants/stats/+page.svelte
+++ b/src/routes/participants/stats/+page.svelte
@@ -18,7 +18,10 @@
 		orgaShirts,
 		participantCount,
 		participants,
-		participantsShirts
+		participantsShirts,
+		vegan,
+		vegetarian,
+		noFoodPreference
 	} = data;
 	const shirtKinds: TShirtSize[] = ['S', 'M', 'L', 'XL', '2XL', '3XL'];
 	const byName = (a: Company, b: Company) =>
@@ -136,7 +139,7 @@
 			</section>
 		</InfoBox>
 
-		<InfoBox title="Allergies">
+		<InfoBox title="Food">
 			<p>
 				There are a couple of participants registered with allergies. Let's try to find food that
 				works for everybody.
@@ -150,7 +153,35 @@
 						</tr>
 					</thead>
 					<tbody>
-						{#each Object.entries(allergies) as [name, amount] (name)}
+						<tr>
+							<td>Vegan</td>
+							<td>{vegan}</td>
+						</tr>
+						<tr>
+							<td>Vegetarian</td>
+							<td>{vegetarian}</td>
+						</tr>
+						<tr>
+							<td>No preference</td>
+							<td>{noFoodPreference}</td>
+						</tr>
+					</tbody>
+				</table>
+				<table>
+					<thead>
+						<tr>
+							<th>Allergy</th>
+							<th>Amount</th>
+						</tr>
+					</thead>
+					<tbody>
+						{#each Object.entries(allergies).toSorted(([_a, amountA], [_b, amountB]) => {
+							const sorted = amountB - amountA;
+							if (sorted === 0) {
+								return _a > _b ? 1 : _a === _b ? 0 : -1;
+							}
+							return sorted;
+						}) as [name, amount] (name)}
 							<tr>
 								<td>{name}</td>
 								<td>{amount}</td>
@@ -231,6 +262,7 @@
 		gap: 1em;
 		grid-template-columns: repeat(auto-fit, minmax(min-content, min(100%, 300px)));
 		justify-content: space-between;
+		align-items: start;
 	}
 	th {
 		text-align: start;


### PR DESCRIPTION
Show the amount of vegan and vegetarian vs no food preference people on the stats page.

Main page could show negative numbers for seats left, which shouldn't be the case.