### PR TITLE
Use new Discord invite link as the other seems to be broken

### DIFF
--- a/src/lib/config/social.ts
+++ b/src/lib/config/social.ts
@@ -1,5 +1,5 @@
 export const socialLinks = {
-	discord: 'https://discord.gg/V44xpxHf',
+	discord: 'https://discord.gg/HNF7hyGNV7',
 	github: 'https://github.com/jscraftcamp',
 	mastodon: 'https://mastodontech.de/@jscraftcamp'
 };


### PR DESCRIPTION
Looks like we had a broken link to Discord! 😱
Thanks to @ugurak001 for finding out. I've generated a new one and replaced the old one with it.