### PR TITLE
fix: mobile view for /registration

### DIFF
--- a/participants/_template.json
+++ b/participants/_template.json
@@ -20,9 +20,9 @@
 	// either both days or at least one day has to be set to true.
 	// If you cannot make one of the days, please set it to false, to allow someone else take that spot!
 	"when": {
-		// June 27th, 2025
+		// June 12th, 2026
 		"friday": true,
-		// June 28th, 2025
+		// June 13th, 2026
 		"saturday": true
 	},
 	// if you are willing to take session notes and publish them to github (required)

--- a/src/routes/registration/+page.svelte
+++ b/src/routes/registration/+page.svelte
@@ -68,7 +68,7 @@
 		<Card>
 			<h2>The JSON format</h2>
 			<p>Your registration as JSON file should be in the following format to pass the tests:</p>
-			<pre>{RegistrationTemplate}</pre>
+			<pre class="template">{RegistrationTemplate}</pre>
 		</Card>
 
 		<Card>
@@ -93,3 +93,10 @@
 		</Card>
 	</Content>
 </PageLayout>
+
+<style>
+	.template {
+		overflow-x: auto;
+		max-width: 100%;
+	}
+</style>


### PR DESCRIPTION
the "code" section is breaking the page layout