### PR TITLE
Add participant information for Manuel Stingl

### DIFF
--- a/participants/mstingl.json
+++ b/participants/mstingl.json
@@ -1,0 +1,44 @@
+// vim: ft=jsonc
+// Please provide your info in your own .json file.
+// See https://jscraftcamp.org/registration for more information
+{
+	// your real name (required by location host)
+	"realName": {
+		"givenName": "Manuel",
+		"familyName": "Stingl",
+		// if you prefer to have your family name shown first (optional)
+		"placeFamilyNameFirst": false,
+		// if you do not want to show your family name on the participant list (optional)
+		"hideFamilyNameOnWebsite": false
+	},
+	// please put in the account name of the PR creator, if you sign up somebody else
+	"githubAccountName": "mstingl",
+	// company name (optional)
+	"company": "StackForge UG",
+	// either both days or at least one day has to be set to true.
+	// If you cannot make one of the days, please set it to false, to allow someone else take that spot!
+	"when": {
+		// June 27th, 2025
+		"friday": true,
+		// June 28th, 2025
+		"saturday": true
+	},
+	// if you are willing to take session notes and publish them to github (required)
+	"iCanTakeNotesDuringSessions": false,
+	// your current interests (JS and in general) (required)
+	"tags": ["TypeScript", "React", "GraphQL", "Next.js", "REST", "PostgreSQL", "Kubernetes"],
+	// if you only eat vegan food (optional)
+	"vegan": false,
+	// if you only eat vegan or vegetarian food (optional)
+	"vegetarian": false,
+	// tell us a few words how JavaScript affects you (required)
+	"whatIsMyConnectionToJavascript": "Started in the days of jQuery, now building frontends with Next.js (even though I'm more a backend guy using Python)",
+	// what can you contribute to the bar camp (required)
+	"whatCanIContribute": "I'm building souvereign system architectures and it-systems beyond what software engineers usually do, making connections actually happen rather then relying on a vendor with magic sauce.",
+	// if you want a T-Shirt we need your size and variant preference (optional)
+	// the following sizes are available: S, M, L, XL, 2XL, 3XL (only regular cut)
+	"tShirtSize": "M",
+	// your LinkedIn profile URL
+	"linkedin": "https://www.linkedin.com/in/manuel-stingl-b143473a3/",
+	"website": "https://www.stack-forge.eu/de"
+}


### PR DESCRIPTION
**I would like to register for JS CraftCamp.**

- [x] My pull request contains a JSON file `$name_or_nickname.json`
- [x] I read the `THE IMPORTANT STUFF` at [https://jscraftcamp.org/registration](https://jscraftcamp.org/registration), the JSON file follows the [template](https://github.com/jscraftcamp/website/blob/main/participants/_template.json), and contains the mandatory fields like `realName`, `githubAccountName`, `when`, `iCanTakeNotesDuringSessions`, `whatIsMyConnectionToJavascript` and `whatCanIContribute`.
- [x] If I can NOT attend, I will either send another pull request removing my JSON file or an e-mail with the subject 'UNREGISTER' to team@jscraftcamp.org
- [x] I agree that the data I enter in the registration can be used for running the event, e.g. make a name tag, count me as participant. I acknowledge that my data are public on GitHub and I agree that I will be listed on the JSCraftCamp website as a participant.
- [x] I agree that photos and videos might be taken and published (e.g. on social media) during the event.
- [x] I understand that I might NOT get a T-Shirt, because they might be in production already
- [x] I asked my company about sponsoring (see open items at: https://github.com/orgs/jscraftcamp/projects/16)

**Are you from a sponsoring company?**

- [x] Yes, I am from **StackForge**

**Optional GIF to show my level of excitement**

<!-- If you like to share some fun GIF with us, try to drag & drop something from giphy.com here ;) -->
