### PR TITLE
fix(participants): does it look better inline?

### DIFF
--- a/src/routes/participants/+page.svelte
+++ b/src/routes/participants/+page.svelte
@@ -169,9 +169,11 @@
 	{#if $registrationState === 'open'}
 		<Card>
 			<h2>Not seeing yourself on the list?</h2>
-			If you can't find yourself on the list of participants, but you want to join, check out our<a
-				href="{base}/registration">how to register</a
-			> page.
+			<span>
+				If you can't find yourself on the list of participants, but you want to join, check out our <a
+					href="{base}/registration">how to register</a
+				> page.
+			</span>
 		</Card>
 	{/if}
 </PageLayout>


### PR DESCRIPTION
This adds inline styling to the how to register section on the participants page.
This looks better to me, but feel free to discard.

Before:
<img width="2218" height="1459" alt="vorher" src="https://github.com/user-attachments/assets/109e0cfa-14d9-4d1e-915e-92b662afe892" />

After:
<img width="2218" height="1459" alt="nachher" src="https://github.com/user-attachments/assets/b3202b90-0ba2-4400-a69f-194d71521d56" />

