### PR TITLE
Jscc26/add crown to sponsors participants

### DIFF
--- a/src/lib/icons/crown.svg
+++ b/src/lib/icons/crown.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24">
+  <path d="M11.562 3.266a.5.5 0 0 1 .876 0L15.39 8.87a1 1 0 0 0 1.516.294L21.183 5.5a.5.5 0 0 1 .798.519l-2.834 10.246a1 1 0 0 1-.956.734H5.81a1 1 0 0 1-.957-.734L2.02 6.02a.5.5 0 0 1 .798-.519l4.276 3.664a1 1 0 0 0 1.516-.294z" />
+  <path d="M5 21h14" />
+</svg>

--- a/src/lib/participants/Participant.svelte
+++ b/src/lib/participants/Participant.svelte
@@ -48,17 +48,20 @@
 			aria-controls="participant-details-{participant.githubAccountName}"
 			class="font-inherit cursor-pointer border-none bg-transparent p-0 text-left text-primary-700 uppercase focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 focus:ring-offset-black focus:outline-none"
 		>
-			{#if participantIsSponsor}<span
-					class="-mt-1 mr-1 inline-block h-4 w-4 align-middle text-primary-500 *:size-full"
-					title="Sponsor"
-					aria-label="Sponsor">{@html crownIcon}</span
-				>{/if}{displayName(participant)}
+			{displayName(participant)}
 		</button>
 	</h3>
 
 	<!-- Company -->
 	{#if participant.company}
-		<h4 class="m-0 overflow-hidden text-sm font-normal text-ellipsis text-gray-300">
+		<h4
+			class="m-0 flex items-center gap-1 overflow-hidden text-sm font-normal text-ellipsis text-gray-300"
+		>
+			{#if participantIsSponsor}<span
+					class="-mt-0.5 inline-block h-3.5 w-3.5 shrink-0 text-primary-500 *:size-full"
+					title="Sponsor"
+					aria-label="Sponsor">{@html crownIcon}</span
+				>{/if}
 			{participant.company}
 		</h4>
 	{/if}

--- a/src/lib/participants/Participant.svelte
+++ b/src/lib/participants/Participant.svelte
@@ -8,6 +8,7 @@
 	import pencilSquareIcon from '$lib/icons/pencil-square.svg?raw';
 	import type { Participant } from '$lib/participants/participant-schema';
 	import { displayName } from '$lib/participants/display-name';
+	import { isSponsor } from '$lib/sponsoring/is-sponsor';
 	import { createEventDispatcher } from 'svelte';
 	import { cn } from '$lib/utils/cn';
 
@@ -27,6 +28,7 @@
 		participant.website ||
 		participant.linkedin;
 
+	const participantIsSponsor = participant.company ? isSponsor(participant.company) : false;
 	const dispatch = createEventDispatcher<{ selectedTag: string }>();
 </script>
 
@@ -45,7 +47,7 @@
 			aria-controls="participant-details-{participant.githubAccountName}"
 			class="font-inherit cursor-pointer border-none bg-transparent p-0 text-left text-primary-700 uppercase focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 focus:ring-offset-black focus:outline-none"
 		>
-			{displayName(participant)}
+			{#if participantIsSponsor}<span title="Sponsor">👑</span>{/if}{displayName(participant)}
 		</button>
 	</h3>
 

--- a/src/lib/participants/Participant.svelte
+++ b/src/lib/participants/Participant.svelte
@@ -6,6 +6,7 @@
 	import xLogo from '$lib/icons/x.svg?raw';
 	import globeIcon from '$lib/icons/globe.svg?raw';
 	import pencilSquareIcon from '$lib/icons/pencil-square.svg?raw';
+	import crownIcon from '$lib/icons/crown.svg?raw';
 	import type { Participant } from '$lib/participants/participant-schema';
 	import { displayName } from '$lib/participants/display-name';
 	import { isSponsor } from '$lib/sponsoring/is-sponsor';
@@ -47,7 +48,11 @@
 			aria-controls="participant-details-{participant.githubAccountName}"
 			class="font-inherit cursor-pointer border-none bg-transparent p-0 text-left text-primary-700 uppercase focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 focus:ring-offset-black focus:outline-none"
 		>
-			{#if participantIsSponsor}<span title="Sponsor">👑</span>{/if}{displayName(participant)}
+			{#if participantIsSponsor}<span
+					class="-mt-1 mr-1 inline-block h-4 w-4 align-middle text-primary-500 *:size-full"
+					title="Sponsor"
+					aria-label="Sponsor">{@html crownIcon}</span
+				>{/if}{displayName(participant)}
 		</button>
 	</h3>
 

--- a/src/routes/archive/2023/stats/+page.svelte
+++ b/src/routes/archive/2023/stats/+page.svelte
@@ -5,6 +5,7 @@
 	import { base } from '$app/paths';
 	import stats from './stats.json';
 	import type { TShirtSize } from '$lib/participants/participant-schema';
+	import crownIcon from '$lib/icons/crown.svg?raw';
 
 	const {
 		allergies,
@@ -202,7 +203,11 @@
 							{#each companies as { name, amount, isSponsor } (name)}
 								<tr class="border-b border-gray-700/50 last:border-b-0">
 									<td class="w-8 px-1 py-2 text-center">
-										{#if isSponsor}<span title="Sponsor">👑</span>{/if}
+										{#if isSponsor}<span
+												class="mt-1 inline-block h-4 w-4 text-primary-500 *:size-full"
+												title="Sponsor"
+												aria-label="Sponsor">{@html crownIcon}</span
+											>{/if}
 									</td>
 									<td class="px-3 py-2 text-gray-300">{name}</td>
 									<td class="px-3 py-2 text-white">{amount}</td>

--- a/src/routes/archive/2024/stats/+page.svelte
+++ b/src/routes/archive/2024/stats/+page.svelte
@@ -5,6 +5,7 @@
 	import { base } from '$app/paths';
 	import stats from './stats.json';
 	import type { TShirtSize } from '$lib/participants/participant-schema';
+	import crownIcon from '$lib/icons/crown.svg?raw';
 
 	const {
 		allergies,
@@ -175,7 +176,11 @@
 							{#each companies as { name, amount, isSponsor } (name)}
 								<tr class="border-b border-gray-700/50 last:border-b-0">
 									<td class="w-8 px-1 py-2 text-center">
-										{#if isSponsor}<span title="Sponsor">👑</span>{/if}
+										{#if isSponsor}<span
+												class="mt-1 inline-block h-4 w-4 text-primary-500 *:size-full"
+												title="Sponsor"
+												aria-label="Sponsor">{@html crownIcon}</span
+											>{/if}
 									</td>
 									<td class="px-3 py-2 text-gray-300">{name}</td>
 									<td class="px-3 py-2 text-white">{amount}</td>

--- a/src/routes/archive/2025/stats/+page.svelte
+++ b/src/routes/archive/2025/stats/+page.svelte
@@ -5,6 +5,7 @@
 	import { base } from '$app/paths';
 	import stats from './stats.json';
 	import type { TShirtSize } from '$lib/participants/participant-schema';
+	import crownIcon from '$lib/icons/crown.svg?raw';
 
 	const {
 		allergies,
@@ -175,7 +176,11 @@
 							{#each companies as { name, amount, isSponsor } (name)}
 								<tr class="border-b border-gray-700/50 last:border-b-0">
 									<td class="w-8 px-1 py-2 text-center">
-										{#if isSponsor}<span title="Sponsor">👑</span>{/if}
+										{#if isSponsor}<span
+												class="mt-1 inline-block h-4 w-4 text-primary-500 *:size-full"
+												title="Sponsor"
+												aria-label="Sponsor">{@html crownIcon}</span
+											>{/if}
 									</td>
 									<td class="px-3 py-2 text-gray-300">{name}</td>
 									<td class="px-3 py-2 text-white">{amount}</td>

--- a/src/routes/participants/stats/+page.svelte
+++ b/src/routes/participants/stats/+page.svelte
@@ -7,6 +7,7 @@
 	import type { PageData } from './$types';
 	import { base } from '$app/paths';
 	import { cn } from '$lib/utils/cn';
+	import crownIcon from '$lib/icons/crown.svg?raw';
 
 	interface Props {
 		data: PageData;
@@ -271,7 +272,11 @@
 							{#each companies.toSorted(actualSorter) as { name, amount, isSponsor } (name)}
 								<tr class="border-b border-gray-700/50 last:border-b-0">
 									<td class="w-8 px-1 py-2 text-center">
-										{#if isSponsor}<span title="Sponsor">👑</span>{/if}
+										{#if isSponsor}<span
+												class="mt-1 inline-block h-4 w-4 text-primary-500 *:size-full"
+												title="Sponsor"
+												aria-label="Sponsor">{@html crownIcon}</span
+											>{/if}
 									</td>
 									<td class="px-3 py-2 text-gray-300">{name}</td>
 									<td class="px-3 py-2 text-white">{amount}</td>


### PR DESCRIPTION
- Proposal for a flat crown icon matches overall style way better.
- Also added a for participants in the participants list

I already though about moving the crown icon to the company below the name to be less visible, ideas ?

Edit: i moved it to the company as i like it way more

<img width="262" height="58" alt="image" src="https://github.com/user-attachments/assets/80c35fa6-b097-48a4-aa9c-b54fb0a789c3" />

<img width="317" height="99" alt="image" src="https://github.com/user-attachments/assets/9fac4c87-dbaf-4bfe-8309-7ecabb4fec3f" />

