### PR TITLE
feat: add ORGA badge to participant cards and switch orga recognition to account names

### DIFF
--- a/src/lib/components/TeamMember.svelte
+++ b/src/lib/components/TeamMember.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import githubIcon from '$lib/icons/github.svg?raw';
+	import codebergIcon from '$lib/icons/codeberg.svg?raw';
 	import mastodonIcon from '$lib/icons/mastodon.svg?raw';
 	import twitterIcon from '$lib/icons/x.svg?raw';
 	import linkedinIcon from '$lib/icons/linkedin.svg?raw';
@@ -9,6 +10,7 @@
 		email?: string;
 		image?: string;
 		github?: string;
+		codeberg?: string;
 		mastodon?: string;
 		twitter?: string;
 		linkedin?: string;
@@ -19,6 +21,7 @@
 		email = undefined,
 		image = undefined,
 		github = undefined,
+		codeberg = undefined,
 		mastodon = undefined,
 		twitter = undefined,
 		linkedin = undefined
@@ -27,6 +30,7 @@
 	const socials = $derived(
 		[
 			{ url: github, icon: githubIcon, label: 'GitHub' },
+			{ url: codeberg, icon: codebergIcon, label: 'Codeberg' },
 			{ url: mastodon, icon: mastodonIcon, label: 'Mastodon' },
 			{ url: twitter, icon: twitterIcon, label: 'Twitter' },
 			{ url: linkedin, icon: linkedinIcon, label: 'LinkedIn' }

--- a/src/lib/config/team/team.ts
+++ b/src/lib/config/team/team.ts
@@ -80,8 +80,13 @@ export const team: TeamMember[] = [
 	}
 ];
 
+export type OrgaUsername = { platform: 'github' | 'codeberg'; username: string };
+
 const extractUsername = (url: string) => url.split('/').pop()!;
 
-export const orgaUsernames: string[] = team.flatMap((m) =>
-	[m.github, m.codeberg].filter((u): u is string => u != null).map(extractUsername)
-);
+export const orgaUsernames: OrgaUsername[] = team.flatMap((m) => {
+	const entries: OrgaUsername[] = [];
+	if (m.github) entries.push({ platform: 'github', username: extractUsername(m.github) });
+	if (m.codeberg) entries.push({ platform: 'codeberg', username: extractUsername(m.codeberg) });
+	return entries;
+});

--- a/src/lib/config/team/team.ts
+++ b/src/lib/config/team/team.ts
@@ -16,11 +16,13 @@ export const team: TeamMember[] = [
 		name: 'Ariadne Engelbrecht',
 		email: 'Ariadne.Engelbrecht@curiosdevcookie.dev',
 		linkedin: 'https://www.linkedin.com/in/ariadne-engelbrecht/',
+		github: 'https://github.com/curiosdevcookie',
 		image: ariadne
 	},
 	{
 		name: 'Bernd Kaiser',
 		linkedin: 'https://www.linkedin.com/in/bernd-kaiser/',
+		github: 'https://github.com/meldron',
 		image: bernd
 	},
 	{
@@ -34,17 +36,20 @@ export const team: TeamMember[] = [
 		name: 'Leo Kettmeir',
 		email: 'leo@deno.com',
 		linkedin: 'https://www.linkedin.com/in/leo-kettmeir/',
+		github: 'https://github.com/crowlkats',
 		image: leo
 	},
 	{
 		name: 'Michael Zoidl',
 		email: 'michael@alm.sh',
+		github: 'https://github.com/michaelzoidl',
 		image: michael
 	},
 	{
 		name: 'Patrick Piedad',
 		email: 'patrickpiedad@gmail.com',
 		linkedin: 'https://www.linkedin.com/in/patrick-piedad/',
+		github: 'https://github.com/patrickpiedad',
 		image: patrickp
 	},
 	{
@@ -70,6 +75,13 @@ export const team: TeamMember[] = [
 		email: 'w@kriesing.de',
 		linkedin: 'https://www.linkedin.com/in/wolframkriesing/',
 		github: 'https://github.com/wolframkriesing',
+		codeberg: 'https://codeberg.org/wolframkriesing',
 		image: wolfram
 	}
 ];
+
+const extractUsername = (url: string) => url.split('/').pop()!;
+
+export const orgaUsernames: string[] = team.flatMap((m) =>
+	[m.github, m.codeberg].filter((u): u is string => u != null).map(extractUsername)
+);

--- a/src/lib/config/team/types.ts
+++ b/src/lib/config/team/types.ts
@@ -3,6 +3,7 @@ export interface TeamMember {
 	email?: string;
 	image?: string;
 	github?: string;
+	codeberg?: string;
 	mastodon?: string;
 	twitter?: string;
 	linkedin?: string;

--- a/src/lib/participants/Participant.svelte
+++ b/src/lib/participants/Participant.svelte
@@ -16,9 +16,10 @@
 	interface Props {
 		participant: Participant;
 		isActive?: boolean;
+		isOrga?: boolean;
 	}
 
-	let { participant, isActive = false }: Props = $props();
+	let { participant, isActive = false, isOrga = false }: Props = $props();
 
 	let isShowingDetails = $state(false);
 	const hasSocialLink =
@@ -180,6 +181,10 @@
 			</ul>
 		{/if}
 	</div>
+
+	{#if isOrga}
+		<span class="absolute bottom-3 left-4 text-xs font-semibold text-gray-500">ORGA</span>
+	{/if}
 
 	<!-- Attendance badges (bottom right) -->
 	<div class="absolute right-4 bottom-3 flex items-center gap-2 text-xs font-semibold">

--- a/src/lib/participants/participants.ts
+++ b/src/lib/participants/participants.ts
@@ -7,18 +7,6 @@ import {
 import { parse } from 'jsonc-parser';
 import { join } from 'node:path';
 
-export const orgaMembers = [
-	{ givenName: 'Ariadne', familyName: 'Engelbrecht' },
-	{ givenName: 'Bernd', familyName: 'Kaiser' },
-	{ givenName: 'Jörn', familyName: 'Bernhardt' },
-	{ givenName: 'Leo', familyName: 'Kettmeir' },
-	{ givenName: 'Michael', familyName: 'Zoidl' },
-	{ givenName: 'Patrick', familyName: 'Piedad' },
-	{ givenName: 'Philip', familyName: 'Saa' },
-	{ givenName: 'Sina', familyName: 'Aschenbrenner' },
-	{ givenName: 'Wolfram', familyName: 'Kriesing' }
-];
-
 export async function loadParticipantJsonFilePaths(directory: string): Promise<string[]> {
 	const participantsDirectory = await readdir(directory, {
 		withFileTypes: true,

--- a/src/lib/participants/statistics.ts
+++ b/src/lib/participants/statistics.ts
@@ -13,7 +13,6 @@ type Shirts = {
 		[key in TShirtSize]?: number;
 	};
 };
-type Name = { givenName: string; familyName: string };
 export type Statistics = {
 	allergies: Allergies;
 	companies: Company[];
@@ -33,9 +32,9 @@ export type Statistics = {
 	noFoodPreference: number;
 };
 
-const isOrgaMember = (p: Name, orgaMembers: Name[]) => {
-	return orgaMembers.some(
-		(m) => `${m.givenName} ${m.familyName}` === `${p.givenName} ${p.familyName}`
+const isOrgaMember = (p: Participant, orgaUsernames: string[]) => {
+	return orgaUsernames.some(
+		(username) => username === p.githubAccountName || username === p.codebergAccountName
 	);
 };
 
@@ -44,7 +43,7 @@ const isNonFoodAllergy = (allergyKey: string) =>
 
 export const createStatsFromParticipants = (
 	participants: Participant[],
-	orgaMembers: Name[]
+	orgaMembers: string[]
 ): Statistics => {
 	const allergies: Allergies = {};
 	const orgaShirts: Shirts = { count: 0, fitted: 0, regular: 0, sizes: {} };
@@ -60,7 +59,7 @@ export const createStatsFromParticipants = (
 
 	for (const participant of participants) {
 		let shirts = participantsShirts;
-		if (isOrgaMember(participant.realName, orgaMembers)) {
+		if (isOrgaMember(participant, orgaMembers)) {
 			shirts = orgaShirts;
 		}
 		if (participant.company) {

--- a/src/lib/participants/statistics.ts
+++ b/src/lib/participants/statistics.ts
@@ -1,6 +1,7 @@
 import { isSponsor } from '$lib/sponsoring/is-sponsor';
 import type { Participant, TShirtSize } from './participant-schema';
 import { normalizeCompanyKey } from './normalize-company';
+import type { OrgaUsername } from '$lib/config/team/team';
 
 type Allergies = { [k: string]: number };
 export type Company = { name: string; amount: number; isSponsor: boolean };
@@ -32,9 +33,11 @@ export type Statistics = {
 	noFoodPreference: number;
 };
 
-const isOrgaMember = (p: Participant, orgaUsernames: string[]) => {
+const isOrgaMember = (p: Participant, orgaUsernames: OrgaUsername[]) => {
 	return orgaUsernames.some(
-		(username) => username === p.githubAccountName || username === p.codebergAccountName
+		({ platform, username }) =>
+			(platform === 'github' && username === p.githubAccountName) ||
+			(platform === 'codeberg' && username === p.codebergAccountName)
 	);
 };
 
@@ -43,7 +46,7 @@ const isNonFoodAllergy = (allergyKey: string) =>
 
 export const createStatsFromParticipants = (
 	participants: Participant[],
-	orgaMembers: string[]
+	orgaMembers: OrgaUsername[]
 ): Statistics => {
 	const allergies: Allergies = {};
 	const orgaShirts: Shirts = { count: 0, fitted: 0, regular: 0, sizes: {} };

--- a/src/routes/participants/+page.server.ts
+++ b/src/routes/participants/+page.server.ts
@@ -2,11 +2,11 @@ import { type Participant, PARTICIPANTS_DIRECTORY } from '$lib/participants/part
 import type { PageServerLoad } from './$types';
 import { loadParticipantJsonFilePaths, loadParticipants } from '$lib/participants/participants';
 import { displayName } from '$lib/participants/display-name';
-import { orgaUsernames } from '$lib/config/team/team';
+import { orgaUsernames, type OrgaUsername } from '$lib/config/team/team';
 
 export const load: PageServerLoad = async (): Promise<{
 	participants: Participant[];
-	orgaUsernames: string[];
+	orgaUsernames: OrgaUsername[];
 }> => {
 	try {
 		const participantsFilePaths = await loadParticipantJsonFilePaths(PARTICIPANTS_DIRECTORY);

--- a/src/routes/participants/+page.server.ts
+++ b/src/routes/participants/+page.server.ts
@@ -2,8 +2,12 @@ import { type Participant, PARTICIPANTS_DIRECTORY } from '$lib/participants/part
 import type { PageServerLoad } from './$types';
 import { loadParticipantJsonFilePaths, loadParticipants } from '$lib/participants/participants';
 import { displayName } from '$lib/participants/display-name';
+import { orgaUsernames } from '$lib/config/team/team';
 
-export const load: PageServerLoad = async (): Promise<{ participants: Participant[] }> => {
+export const load: PageServerLoad = async (): Promise<{
+	participants: Participant[];
+	orgaUsernames: string[];
+}> => {
 	try {
 		const participantsFilePaths = await loadParticipantJsonFilePaths(PARTICIPANTS_DIRECTORY);
 
@@ -21,7 +25,7 @@ export const load: PageServerLoad = async (): Promise<{ participants: Participan
 			return 0;
 		});
 
-		return { participants };
+		return { participants, orgaUsernames };
 	} catch (err) {
 		console.error('Loading of participants failed:', err);
 		throw err;

--- a/src/routes/participants/+page.svelte
+++ b/src/routes/participants/+page.svelte
@@ -22,6 +22,10 @@
 	let { data }: Props = $props();
 
 	const participants: ParticipantT[] = data.participants;
+	const orgaSet = new Set(data.orgaUsernames);
+	const isOrga = (p: ParticipantT) =>
+		(p.githubAccountName != null && orgaSet.has(p.githubAccountName)) ||
+		(p.codebergAccountName != null && orgaSet.has(p.codebergAccountName));
 	let activeTag: string | null = $state(null);
 
 	const onSelectTag = (e: CustomEvent<string>) => {
@@ -161,6 +165,7 @@
 							<Participant
 								{participant}
 								on:selectedTag={onSelectTag}
+								isOrga={isOrga(participant)}
 								isActive={(activeTag &&
 									participant.tags
 										.map((t) => t.toLocaleLowerCase())

--- a/src/routes/participants/+page.svelte
+++ b/src/routes/participants/+page.svelte
@@ -22,10 +22,15 @@
 	let { data }: Props = $props();
 
 	const participants: ParticipantT[] = data.participants;
-	const orgaSet = new Set(data.orgaUsernames);
+	const githubOrgaSet = new Set(
+		data.orgaUsernames.filter((o) => o.platform === 'github').map((o) => o.username)
+	);
+	const codebergOrgaSet = new Set(
+		data.orgaUsernames.filter((o) => o.platform === 'codeberg').map((o) => o.username)
+	);
 	const isOrga = (p: ParticipantT) =>
-		(p.githubAccountName != null && orgaSet.has(p.githubAccountName)) ||
-		(p.codebergAccountName != null && orgaSet.has(p.codebergAccountName));
+		(p.githubAccountName != null && githubOrgaSet.has(p.githubAccountName)) ||
+		(p.codebergAccountName != null && codebergOrgaSet.has(p.codebergAccountName));
 	let activeTag: string | null = $state(null);
 
 	const onSelectTag = (e: CustomEvent<string>) => {

--- a/src/routes/participants/stats/+page.server.ts
+++ b/src/routes/participants/stats/+page.server.ts
@@ -1,11 +1,12 @@
 import type { PageServerLoad } from './$types';
-import { loadAllParticipants, orgaMembers } from '$lib/participants/participants';
+import { loadAllParticipants } from '$lib/participants/participants';
 import { createStatsFromParticipants, type Statistics } from '$lib/participants/statistics';
+import { orgaUsernames } from '$lib/config/team/team';
 
 export const load: PageServerLoad = async (): Promise<Statistics> => {
 	try {
 		const participants = await loadAllParticipants();
-		return createStatsFromParticipants(participants, orgaMembers);
+		return createStatsFromParticipants(participants, orgaUsernames);
 	} catch (err) {
 		console.error('Loading of participants failed:', err);
 		throw err;


### PR DESCRIPTION
@Narigo asked me to check how the orga counter on the stats page is working and if we can add "orga" to the participant cards for easier manual counting.

- Added "ORGA" (light gray) to the bottom left of the participant card
- Changed orga recognition from "firstname, lastname" to GitHub/Codeberg account name

This required all orga members to have a GitHub or Codeberg account set in the team config, which is currently the case for all but Sina.

@wolframkriesing I saw that you don't have a GitHub account in your participants.json anymore but still on the orga page. Should I remove it there as well?