### PR TITLE
refactor: extract drag-scroll action and shuffle into utils

### DIFF
--- a/src/lib/components/CurrentSponsorsCard.svelte
+++ b/src/lib/components/CurrentSponsorsCard.svelte
@@ -2,6 +2,8 @@
 	import { sponsors, thankYouTranslations } from '$lib/config/sponsoring';
 	import Card from '$lib/layout/Card.svelte';
 	import { cn } from '$lib/utils/cn';
+	import { dragScroll } from '$lib/utils/drag-scroll';
+	import { shuffle } from '$lib/utils/shuffle';
 	import { onMount } from 'svelte';
 
 	interface Props {
@@ -11,18 +13,12 @@
 	let { class: className = '' }: Props = $props();
 
 	// Shuffle sponsor order on every page load so no sponsor is always first/last.
-	// Must happen after mount to avoid SSR/hydration mismatch (server and client
-	// would produce different random orders, desyncing logos from names).
+	// Must happen after mount to avoid SSR/hydration mismatch.
 	let baseSponsors = $state([...sponsors]);
 	let ready = $state(false);
 
 	onMount(() => {
-		const shuffled = [...sponsors];
-		for (let i = shuffled.length - 1; i > 0; i--) {
-			const j = Math.floor(Math.random() * (i + 1));
-			[shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
-		}
-		baseSponsors = shuffled;
+		baseSponsors = shuffle(sponsors);
 		ready = true;
 	});
 
@@ -50,209 +46,6 @@
 	);
 
 	const scrollDuration = $derived(`${Math.max(10, baseSponsors.length * 2.5)}s`);
-
-	/**
-	 * Svelte action that adds drag-to-scroll to an infinite-scrolling element.
-	 * Works alongside CSS animations — freezes during drag, then resumes from the new position.
-	 */
-	function dragScroll(node: HTMLElement) {
-		let isDragging = false;
-		let hasMoved = false;
-		let frozen = false; // true while the CSS animation is paused and we control the transform
-		let startX = 0;
-		let dragStartTranslateX = 0;
-		let resumeTimer: ReturnType<typeof setTimeout> | null = null;
-		let momentumRaf: number | null = null;
-
-		// Velocity tracking – store the last two move events for a reliable reading
-		let prevMoveX = 0;
-		let prevMoveTime = 0;
-		let lastMoveX = 0;
-		let lastMoveTime = 0;
-
-		const FRICTION = 0.95;
-		const MIN_VELOCITY = 0.5; // px/frame – stop momentum below this
-
-		function getCurrentTranslateX(): number {
-			const matrix = new DOMMatrix(getComputedStyle(node).transform);
-			return matrix.m41;
-		}
-
-		function wrapPosition(x: number): number {
-			const halfWidth = node.offsetWidth / 2;
-			if (halfWidth <= 0) return x;
-			return ((x % halfWidth) - halfWidth) % halfWidth;
-		}
-
-		function cancelPendingResume() {
-			if (resumeTimer !== null) {
-				clearTimeout(resumeTimer);
-				resumeTimer = null;
-			}
-		}
-
-		function cancelMomentum() {
-			if (momentumRaf !== null) {
-				cancelAnimationFrame(momentumRaf);
-				momentumRaf = null;
-			}
-		}
-
-		/** Restore the CSS animation, seeking to the position the element is currently frozen at. */
-		function resumeAnimation() {
-			resumeTimer = null;
-
-			const currentX = getCurrentTranslateX();
-			const halfWidth = node.offsetWidth / 2;
-			const isLeft = node.classList.contains('animate-scroll-left');
-
-			let progress: number;
-			if (isLeft) {
-				progress = -currentX / halfWidth;
-			} else {
-				progress = 1 + currentX / halfWidth;
-			}
-			progress = ((progress % 1) + 1) % 1;
-
-			const duration = parseFloat(node.dataset.duration || '25');
-			const delay = -(progress * duration);
-			const animName = isLeft ? 'scroll-left' : 'scroll-right';
-
-			// Set the full animation (with delay) in one step so the browser never
-			// paints a frame at the wrong position.
-			frozen = false;
-			node.style.removeProperty('transform');
-			node.style.animation = `${animName} ${duration}s linear ${delay}s infinite`;
-		}
-
-		/** Animate a decelerating throw, then hand back to the CSS animation. */
-		function startMomentum(velocity: number) {
-			let currentX = getCurrentTranslateX();
-
-			function tick() {
-				velocity *= FRICTION;
-
-				if (Math.abs(velocity) < MIN_VELOCITY) {
-					momentumRaf = null;
-					// Momentum spent – wait 1 s then resume auto-scroll
-					resumeTimer = setTimeout(resumeAnimation, 1000);
-					return;
-				}
-
-				currentX = wrapPosition(currentX + velocity);
-				node.style.transform = `translateX(${currentX}px)`;
-				momentumRaf = requestAnimationFrame(tick);
-			}
-
-			momentumRaf = requestAnimationFrame(tick);
-		}
-
-		function onPointerDown(e: PointerEvent) {
-			if (e.button !== 0) return;
-			cancelPendingResume();
-			cancelMomentum();
-			isDragging = true;
-			hasMoved = false;
-			startX = e.clientX;
-			dragStartTranslateX = getCurrentTranslateX();
-			prevMoveX = lastMoveX = e.clientX;
-			prevMoveTime = lastMoveTime = performance.now();
-		}
-
-		function onPointerMove(e: PointerEvent) {
-			if (!isDragging) return;
-			const delta = e.clientX - startX;
-
-			// Only start dragging after a small threshold to avoid interfering with clicks
-			if (!hasMoved && Math.abs(delta) < 4) return;
-
-			if (!hasMoved) {
-				hasMoved = true;
-				// Capture pointer only once a real drag starts, so simple clicks
-				// still reach child <a> elements normally.
-				node.setPointerCapture(e.pointerId);
-				dragStartTranslateX = getCurrentTranslateX();
-				startX = e.clientX;
-				// Take over from CSS animation
-				frozen = true;
-				node.style.animation = 'none';
-				node.style.transform = `translateX(${dragStartTranslateX}px)`;
-				document.body.style.userSelect = 'none';
-				node.style.cursor = 'grabbing';
-			}
-
-			// Track velocity from the last two events
-			prevMoveX = lastMoveX;
-			prevMoveTime = lastMoveTime;
-			lastMoveX = e.clientX;
-			lastMoveTime = performance.now();
-
-			const newX = wrapPosition(dragStartTranslateX + delta);
-			node.style.transform = `translateX(${newX}px)`;
-		}
-
-		function onPointerUp() {
-			if (!isDragging) return;
-			isDragging = false;
-			document.body.style.removeProperty('user-select');
-			node.style.removeProperty('cursor');
-
-			if (!hasMoved) {
-				// A click (no drag) may have interrupted momentum/resume via
-				// onPointerDown. If the animation is still frozen, resume it.
-				if (frozen) {
-					resumeAnimation();
-				}
-				return;
-			}
-
-			// Calculate release velocity (px/ms → px/frame at ~60fps ≈ ×16.67)
-			const dt = lastMoveTime - prevMoveTime;
-			const dx = lastMoveX - prevMoveX;
-			const velocity = dt > 0 ? (dx / dt) * 16.67 : 0;
-
-			if (Math.abs(velocity) > MIN_VELOCITY) {
-				startMomentum(velocity);
-			} else {
-				// No meaningful velocity – just wait then resume
-				resumeTimer = setTimeout(resumeAnimation, 1000);
-			}
-		}
-
-		// Prevent link navigation when the user was dragging (not clicking)
-		function onClick(e: MouseEvent) {
-			if (hasMoved) {
-				e.preventDefault();
-				e.stopPropagation();
-				hasMoved = false;
-			}
-		}
-
-		// Prevent native browser drag on links/images so pointer events keep firing
-		function onDragStart(e: DragEvent) {
-			e.preventDefault();
-		}
-
-		node.addEventListener('pointerdown', onPointerDown);
-		node.addEventListener('pointermove', onPointerMove);
-		node.addEventListener('pointerup', onPointerUp);
-		node.addEventListener('pointercancel', onPointerUp);
-		node.addEventListener('click', onClick, true);
-		node.addEventListener('dragstart', onDragStart);
-
-		return {
-			destroy() {
-				cancelMomentum();
-				cancelPendingResume();
-				node.removeEventListener('pointerdown', onPointerDown);
-				node.removeEventListener('pointermove', onPointerMove);
-				node.removeEventListener('pointerup', onPointerUp);
-				node.removeEventListener('pointercancel', onPointerUp);
-				node.removeEventListener('click', onClick, true);
-				node.removeEventListener('dragstart', onDragStart);
-			}
-		};
-	}
 </script>
 
 <Card

--- a/src/lib/utils/drag-scroll.ts
+++ b/src/lib/utils/drag-scroll.ts
@@ -1,0 +1,235 @@
+/**
+ * Svelte action: drag-to-scroll with momentum for infinite-scrolling elements.
+ *
+ * Lifecycle:  CSS animation ──► drag (frozen) ──► throw (momentum) ──► 1 s pause ──► CSS animation
+ *
+ * Expects the element to use duplicated content (first half = second half)
+ * and one of the CSS classes `animate-scroll-left` or `animate-scroll-right`.
+ * The animation duration is read from `data-duration` (seconds).
+ */
+
+// ── constants ──────────────────────────────────────────────────────
+
+const FRICTION = 0.95; // multiplied each frame — closer to 1 = longer slide
+const STOP_THRESHOLD = 0.5; // px per frame — below this the throw is done
+const RESUME_DELAY = 1000; // ms to wait after throw before auto-scroll resumes
+const DRAG_THRESHOLD = 4; // px of movement before a click becomes a drag
+const MS_PER_FRAME = 16.67; // ≈ 60 fps
+
+// ── geometry helpers ───────────────────────────────────────────────
+
+/** Read the element's current translateX (works with CSS animations and inline transforms). */
+function readTranslateX(el: HTMLElement): number {
+	return new DOMMatrix(getComputedStyle(el).transform).m41;
+}
+
+/** Width of one copy of the duplicated content (= half the element). */
+function oneLoopWidth(el: HTMLElement): number {
+	return el.offsetWidth / 2;
+}
+
+/**
+ * Keep `x` inside one loop period: [−loopWidth, 0).
+ * Prevents visible jumps at the seam of the duplicated content.
+ */
+function wrapX(el: HTMLElement, x: number): number {
+	const w = oneLoopWidth(el);
+	if (w <= 0) return x;
+	return (((x % w) + w) % w) - w;
+}
+
+// ── the action ─────────────────────────────────────────────────────
+
+export function dragScroll(node: HTMLElement) {
+	// state
+	let isDragging = false;
+	let hasMoved = false;
+	let frozen = false;
+	let startX = 0;
+	let anchorX = 0;
+	let resumeTimer: ReturnType<typeof setTimeout> | null = null;
+	let momentumRaf: number | null = null;
+
+	// velocity tracking (last two pointer positions)
+	let prevPointerX = 0;
+	let prevPointerTime = 0;
+	let lastPointerX = 0;
+	let lastPointerTime = 0;
+
+	// ── timers / animation management ──────────────────────────────
+
+	function clearTimer() {
+		if (resumeTimer !== null) {
+			clearTimeout(resumeTimer);
+			resumeTimer = null;
+		}
+	}
+
+	function stopMomentum() {
+		if (momentumRaf !== null) {
+			cancelAnimationFrame(momentumRaf);
+			momentumRaf = null;
+		}
+	}
+
+	function stopEverything() {
+		clearTimer();
+		stopMomentum();
+	}
+
+	// ── freeze / resume CSS animation ──────────────────────────────
+
+	/** Freeze the CSS animation and take manual control. Returns the frozen position. */
+	function freeze(): number {
+		const x = readTranslateX(node);
+		frozen = true;
+		node.style.animation = 'none';
+		node.style.transform = `translateX(${x}px)`;
+		return x;
+	}
+
+	/** Hand control back to the CSS animation, continuing from the current position. */
+	function resumeAutoScroll() {
+		resumeTimer = null;
+
+		const x = readTranslateX(node);
+		const w = oneLoopWidth(node);
+		const isLeft = node.classList.contains('animate-scroll-left');
+		const duration = parseFloat(node.dataset.duration || '25');
+
+		// How far through one loop is the current position? (0 → 1)
+		//   scroll-left  moves  0 → −w   →  progress = −x / w
+		//   scroll-right moves −w →  0   →  progress = (w + x) / w
+		const progress = isLeft ? -x / w : (w + x) / w;
+		const normalised = ((progress % 1) + 1) % 1;
+
+		// A negative delay = "start this many seconds in" → seeks the animation
+		const seekSeconds = -(normalised * duration);
+		const animName = isLeft ? 'scroll-left' : 'scroll-right';
+
+		frozen = false;
+		node.style.removeProperty('transform');
+		node.style.animation = `${animName} ${duration}s linear ${seekSeconds}s infinite`;
+	}
+
+	// ── momentum (throw) ───────────────────────────────────────────
+
+	function startThrow(pixelsPerFrame: number) {
+		let speed = pixelsPerFrame;
+		let x = readTranslateX(node);
+
+		function tick() {
+			speed *= FRICTION;
+
+			if (Math.abs(speed) < STOP_THRESHOLD) {
+				momentumRaf = null;
+				resumeTimer = setTimeout(resumeAutoScroll, RESUME_DELAY);
+				return;
+			}
+
+			x = wrapX(node, x + speed);
+			node.style.transform = `translateX(${x}px)`;
+			momentumRaf = requestAnimationFrame(tick);
+		}
+
+		momentumRaf = requestAnimationFrame(tick);
+	}
+
+	// ── pointer events ─────────────────────────────────────────────
+
+	function onPointerDown(e: PointerEvent) {
+		if (e.button !== 0) return;
+		stopEverything();
+		isDragging = true;
+		hasMoved = false;
+		startX = e.clientX;
+		prevPointerX = lastPointerX = e.clientX;
+		prevPointerTime = lastPointerTime = performance.now();
+	}
+
+	function onPointerMove(e: PointerEvent) {
+		if (!isDragging) return;
+
+		if (!hasMoved) {
+			if (Math.abs(e.clientX - startX) < DRAG_THRESHOLD) return;
+
+			hasMoved = true;
+			node.setPointerCapture(e.pointerId);
+
+			// Snapshot position *now* (the CSS animation kept moving since pointerdown)
+			anchorX = freeze();
+			startX = e.clientX;
+
+			document.body.style.userSelect = 'none';
+			node.style.cursor = 'grabbing';
+		}
+
+		// Track the two most recent positions for velocity
+		prevPointerX = lastPointerX;
+		prevPointerTime = lastPointerTime;
+		lastPointerX = e.clientX;
+		lastPointerTime = performance.now();
+
+		const dragDelta = e.clientX - startX;
+		node.style.transform = `translateX(${wrapX(node, anchorX + dragDelta)}px)`;
+	}
+
+	function onPointerUp() {
+		if (!isDragging) return;
+		isDragging = false;
+		document.body.style.removeProperty('user-select');
+		node.style.removeProperty('cursor');
+
+		if (!hasMoved) {
+			// Just a click — if we interrupted a throw / pause, resume scrolling
+			if (frozen) resumeAutoScroll();
+			return;
+		}
+
+		// Convert pointer velocity from px/ms to px/frame
+		const dt = lastPointerTime - prevPointerTime;
+		const dx = lastPointerX - prevPointerX;
+		const pixelsPerFrame = dt > 0 ? (dx / dt) * MS_PER_FRAME : 0;
+
+		if (Math.abs(pixelsPerFrame) > STOP_THRESHOLD) {
+			startThrow(pixelsPerFrame);
+		} else {
+			resumeTimer = setTimeout(resumeAutoScroll, RESUME_DELAY);
+		}
+	}
+
+	/** Block link navigation when the gesture was a drag, not a click. */
+	function onClick(e: MouseEvent) {
+		if (hasMoved) {
+			e.preventDefault();
+			e.stopPropagation();
+			hasMoved = false;
+		}
+	}
+
+	/** Prevent the browser's native drag on links / images. */
+	function onDragStart(e: DragEvent) {
+		e.preventDefault();
+	}
+
+	// ── bind / unbind ──────────────────────────────────────────────
+
+	node.addEventListener('pointerdown', onPointerDown);
+	node.addEventListener('pointermove', onPointerMove);
+	node.addEventListener('pointerup', onPointerUp);
+	node.addEventListener('pointercancel', onPointerUp);
+	node.addEventListener('click', onClick, true);
+	node.addEventListener('dragstart', onDragStart);
+
+	return {
+		destroy() {
+			stopEverything();
+			node.removeEventListener('pointerdown', onPointerDown);
+			node.removeEventListener('pointermove', onPointerMove);
+			node.removeEventListener('pointerup', onPointerUp);
+			node.removeEventListener('pointercancel', onPointerUp);
+			node.removeEventListener('click', onClick, true);
+			node.removeEventListener('dragstart', onDragStart);
+		}
+	};
+}

--- a/src/lib/utils/shuffle.ts
+++ b/src/lib/utils/shuffle.ts
@@ -1,0 +1,9 @@
+/** Fisher-Yates shuffle — returns a new array in uniformly random order. */
+export function shuffle<T>(array: readonly T[]): T[] {
+	const result = [...array];
+	for (let i = result.length - 1; i > 0; i--) {
+		const j = Math.floor(Math.random() * (i + 1));
+		[result[i], result[j]] = [result[j], result[i]];
+	}
+	return result;
+}


### PR DESCRIPTION
As mentioned by @Narigo code was quite unreadable by humans.

Moves the dragScroll and shuffle out of the component into dedicated utility files, to  keep the component more readable.

- ../utils/drag-scroll.ts — reusable dragScroll (including comments to make it humanreadable)
- ../utils/shuffle.ts — generic Fisher-Yates shuffle

