### PR TITLE
Add "What is JSCraftCamp?" and "All Skill Levels" cards to start page

### DIFF
--- a/src/lib/components/SkillLevelsCard.svelte
+++ b/src/lib/components/SkillLevelsCard.svelte
@@ -20,15 +20,21 @@
 		</div>
 
 		<div class="flex items-center gap-3">
-			<span class="rounded-full bg-primary-700/20 px-4 py-1.5 text-sm font-semibold text-primary-500">
+			<span
+				class="rounded-full bg-primary-700/20 px-4 py-1.5 text-sm font-semibold text-primary-500"
+			>
 				Beginners
 			</span>
 			<span class="text-sm text-white/40">&bull;</span>
-			<span class="rounded-full bg-primary-700/20 px-4 py-1.5 text-sm font-semibold text-primary-500">
+			<span
+				class="rounded-full bg-primary-700/20 px-4 py-1.5 text-sm font-semibold text-primary-500"
+			>
 				Intermediate
 			</span>
 			<span class="text-sm text-white/40">&bull;</span>
-			<span class="rounded-full bg-primary-700/20 px-4 py-1.5 text-sm font-semibold text-primary-500">
+			<span
+				class="rounded-full bg-primary-700/20 px-4 py-1.5 text-sm font-semibold text-primary-500"
+			>
 				Experts
 			</span>
 		</div>

--- a/src/lib/components/SkillLevelsCard.svelte
+++ b/src/lib/components/SkillLevelsCard.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+	import Card from '$lib/layout/Card.svelte';
+	import { cn } from '$lib/utils/cn';
+
+	interface Props {
+		class?: string;
+	}
+
+	let { class: className = '' }: Props = $props();
+</script>
+
+<Card class={cn('px-6 py-6', className)}>
+	<div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+		<div>
+			<h3 class="text-primary-500">All Skill Levels Welcome</h3>
+			<p class="mt-1 text-sm text-white/60">
+				Share what you know, learn what you don't. At JSCraftCamp, juniors teach seniors and seniors
+				learn from juniors. Everyone has something to contribute.
+			</p>
+		</div>
+
+		<div class="flex items-center gap-3">
+			<span class="rounded-full bg-primary-700/20 px-4 py-1.5 text-sm font-semibold text-primary-500">
+				Beginners
+			</span>
+			<span class="text-sm text-white/40">&bull;</span>
+			<span class="rounded-full bg-primary-700/20 px-4 py-1.5 text-sm font-semibold text-primary-500">
+				Intermediate
+			</span>
+			<span class="text-sm text-white/40">&bull;</span>
+			<span class="rounded-full bg-primary-700/20 px-4 py-1.5 text-sm font-semibold text-primary-500">
+				Experts
+			</span>
+		</div>
+	</div>
+</Card>

--- a/src/lib/components/SponsorRequiredCard.svelte
+++ b/src/lib/components/SponsorRequiredCard.svelte
@@ -31,7 +31,7 @@
 		<h3 class="text-xl font-bold sm:text-2xl">Become a Sponsor</h3>
 
 		<p class="text-sm leading-relaxed text-white/60 sm:text-base">
-			For almost 10 years, JSCraftCamp has brought developers together — free and run by volunteers.
+			JSCraftCamp is free and run by volunteers.
 			Help us make {getYear()} happen and connect with passionate tech enthusiasts.
 		</p>
 

--- a/src/lib/components/SponsorRequiredCard.svelte
+++ b/src/lib/components/SponsorRequiredCard.svelte
@@ -31,8 +31,8 @@
 		<h3 class="text-xl font-bold sm:text-2xl">Become a Sponsor</h3>
 
 		<p class="text-sm leading-relaxed text-white/60 sm:text-base">
-			JSCraftCamp is free and run by volunteers.
-			Help us make {getYear()} happen and connect with passionate tech enthusiasts.
+			JSCraftCamp is free and run by volunteers. Help us make {getYear()} happen and connect with passionate
+			tech enthusiasts.
 		</p>
 
 		<div class="mt-auto flex flex-col gap-3 pt-2">

--- a/src/lib/components/TimelineCard.svelte
+++ b/src/lib/components/TimelineCard.svelte
@@ -40,7 +40,7 @@
 	}
 </script>
 
-<Card class={cn('h-full justify-between px-2 py-4 sm:px-4 sm:py-4', className)}>
+<Card class={cn('h-full justify-between px-2 py-6 sm:px-6 sm:py-8', className)}>
 	<div class="flex items-baseline gap-2">
 		<span class="inline-block w-24 font-bold text-primary-700">{agenda.dayLabel}</span>
 		<span class="inline-block w-24 text-primary-700">{agenda.date}</span>

--- a/src/lib/components/WhatIsJSCraftCampCard.svelte
+++ b/src/lib/components/WhatIsJSCraftCampCard.svelte
@@ -22,16 +22,20 @@
 				stroke="currentColor"
 				stroke-width="2"
 			>
-				<path stroke-linecap="round" stroke-linejoin="round" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+				<path
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+				/>
 			</svg>
 		</div>
 
 		<h3 class="text-xl font-bold sm:text-2xl">What is JSCraftCamp?</h3>
 
 		<p class="text-sm leading-relaxed text-white/60 sm:text-base">
-			A free, community-driven JavaScript unconference in Munich. For almost 10 years,
-			developers of all backgrounds have come together for two days of open sessions, workshops,
-			and discussions. No fixed agenda. Participants shape the program on the day.
+			A free, community-driven JavaScript unconference in Munich. For almost 10 years, developers of
+			all backgrounds have come together for two days of open sessions, workshops, and discussions.
+			No fixed agenda. Participants shape the program on the day.
 		</p>
 	</div>
 </Card>

--- a/src/lib/components/WhatIsJSCraftCampCard.svelte
+++ b/src/lib/components/WhatIsJSCraftCampCard.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+	import Card from '$lib/layout/Card.svelte';
+	import { cn } from '$lib/utils/cn';
+
+	interface Props {
+		class?: string;
+	}
+
+	let { class: className = '' }: Props = $props();
+</script>
+
+<Card class={cn('relative overflow-hidden p-6', className)}>
+	<div class="flex h-full flex-col gap-4">
+		<div
+			class="flex h-11 w-11 items-center justify-center rounded-xl bg-primary-700/20 text-primary-500"
+		>
+			<svg
+				xmlns="http://www.w3.org/2000/svg"
+				class="h-6 w-6"
+				fill="none"
+				viewBox="0 0 24 24"
+				stroke="currentColor"
+				stroke-width="2"
+			>
+				<path stroke-linecap="round" stroke-linejoin="round" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+			</svg>
+		</div>
+
+		<h3 class="text-xl font-bold sm:text-2xl">What is JSCraftCamp?</h3>
+
+		<p class="text-sm leading-relaxed text-white/60 sm:text-base">
+			A free, community-driven JavaScript unconference in Munich. For almost 10 years,
+			developers of all backgrounds have come together for two days of open sessions, workshops,
+			and discussions. No fixed agenda. Participants shape the program on the day.
+		</p>
+	</div>
+</Card>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -50,8 +50,18 @@
 			<EventPhotos class="lg:col-span-2" photos={data.eventPhotos} />
 
 			<!-- Row 6: Timelines (full width, taller) -->
-			<Timeline class="min-h-48 lg:col-span-3" agenda={fridayAgenda} slots={allTimeSlots} registered={data.fridayParticipants} />
-			<Timeline class="min-h-48 lg:col-span-3" agenda={saturdayAgenda} slots={allTimeSlots} registered={data.saturdayParticipants} />
+			<Timeline
+				class="min-h-48 lg:col-span-3"
+				agenda={fridayAgenda}
+				slots={allTimeSlots}
+				registered={data.fridayParticipants}
+			/>
+			<Timeline
+				class="min-h-48 lg:col-span-3"
+				agenda={saturdayAgenda}
+				slots={allTimeSlots}
+				registered={data.saturdayParticipants}
+			/>
 		</div>
 	</Content>
 	<Content>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -9,6 +9,8 @@
 	import EventPhotos from '$lib/components/EventPhotosCard.svelte';
 	import LocationCard from '$lib/components/LocationCard.svelte';
 	import RegistrationCard from '$lib/components/RegistrationCard.svelte';
+	import SkillLevelsCard from '$lib/components/SkillLevelsCard.svelte';
+	import WhatIsJSCraftCamp from '$lib/components/WhatIsJSCraftCampCard.svelte';
 	import { fridayAgenda, saturdayAgenda, allTimeSlots } from '$lib/config/agenda';
 	import { eventConfig } from '$lib/config/event';
 	import type { PageData } from './$types';
@@ -28,28 +30,28 @@
 <PageLayout>
 	<Content>
 		<div class="grid grid-cols-1 gap-4 pb-8 lg:grid-cols-3">
-			<!-- Row 1: Header + SponsorRequired -->
+			<!-- Row 1: Header + What is JSCraftCamp -->
 			<Header class="lg:col-span-2" {spotsLeft} />
-			<SponsorRequired />
+			<WhatIsJSCraftCamp />
 
-			<!-- Row 2: SponsorCard (full width) -->
+			<!-- Row 2: Skill Levels (full width) -->
+			<SkillLevelsCard class="lg:col-span-3" />
+
+			<!-- Row 3: Sponsors (full width) -->
 			<SponsorCard class="lg:col-span-3" />
 
-			<!-- Row 3: Photo + Location + Unconference -->
-			<EventPhotos photos={data.eventPhotos} />
+			<!-- Row 4: Become a Sponsor + Location + Unconference -->
+			<SponsorRequired />
 			<LocationCard />
 			<UnconferenceDescription />
 
-			<!-- Row 4: Registration + Timelines -->
+			<!-- Row 5: Registration + Photos (2 cols) -->
 			<RegistrationCard />
-			<div class="flex h-full flex-col justify-between gap-4 lg:col-span-2">
-				<Timeline agenda={fridayAgenda} slots={allTimeSlots} registered={data.fridayParticipants} />
-				<Timeline
-					agenda={saturdayAgenda}
-					slots={allTimeSlots}
-					registered={data.saturdayParticipants}
-				/>
-			</div>
+			<EventPhotos class="lg:col-span-2" photos={data.eventPhotos} />
+
+			<!-- Row 6: Timelines (full width, taller) -->
+			<Timeline class="min-h-48 lg:col-span-3" agenda={fridayAgenda} slots={allTimeSlots} registered={data.fridayParticipants} />
+			<Timeline class="min-h-48 lg:col-span-3" agenda={saturdayAgenda} slots={allTimeSlots} registered={data.saturdayParticipants} />
 		</div>
 	</Content>
 	<Content>


### PR DESCRIPTION
## Summary

Closes #2378

- Add a **"What is JSCraftCamp?"** card next to the header explaining what the event is (free, community-driven JS unconference in Munich, ~10 years running, participant-driven agenda)
- Add an **"All Skill Levels Welcome"** card making it clear that beginners, intermediate, and experts are all welcome
- Rearrange the start page grid for a better content flow: header → skill levels → sponsors → sponsor CTA / location / unconference → registration / photos → full-width agenda timelines
- Give timeline cards more breathing room with increased padding
- Remove duplicate "almost 10 years" copy from the sponsor card