### PR TITLE
Add participant lea

### DIFF
--- a/participants/lea_jell.json
+++ b/participants/lea_jell.json
@@ -34,7 +34,7 @@
 	// tell us a few words how JavaScript affects you (required)
 	"whatIsMyConnectionToJavascript": "My working place is working solely with a JavaScript stack, so I am using JavaScript on a daily basis. I am also interested in the ecosystem and the community around it.",
 	// what can you contribute to the bar camp (required)
-	"whatCanIContribute": "???",
+	"whatCanIContribute": "Coffee sponsoring (see company). If there are Vue specific interests, I could try to do a session, but I don't have any ideas myself yet.",
 	// if you want a T-Shirt we need your size and variant preference (optional)
 	// the following sizes are available: S, M, L, XL, 2XL, 3XL (only regular cut)
 	"tShirtSize": "M",

--- a/participants/lea_jell.json
+++ b/participants/lea_jell.json
@@ -1,0 +1,45 @@
+// vim: ft=jsonc
+// Please provide your info in your own .json file.
+// See https://jscraftcamp.org/registration for more information
+{
+	// your real name (required by location host)
+	"realName": {
+		"givenName": "Lea",
+		"familyName": "Jell",
+		// if you prefer to have your family name shown first (optional)
+		"placeFamilyNameFirst": false,
+		// if you do not want to show your family name on the participant list (optional)
+		"hideFamilyNameOnWebsite": false
+	},
+	// please put in the account name of the PR creator, if you sign up somebody else
+	"githubAccountName": "leje512",
+	// company name (optional)
+	"company": "Peerigon GmbH",
+	// either both days or at least one day has to be set to true.
+	// If you cannot make one of the days, please set it to false, to allow someone else take that spot!
+	"when": {
+		// June 12th, 2026
+		"friday": true,
+		// June 13th, 2026
+		"saturday": true
+	},
+	// if you are willing to take session notes and publish them to github (required)
+	"iCanTakeNotesDuringSessions": false,
+	// your current interests (JS and in general) (required)
+	"tags": ["TypeScript", "Vue", "Vercel", "Clean Code"],
+	// if you only eat vegan food (optional)
+	"vegan": false,
+	// if you only eat vegan or vegetarian food (optional)
+	"vegetarian": true,
+	// tell us a few words how JavaScript affects you (required)
+	"whatIsMyConnectionToJavascript": "My working place is working solely with a JavaScript stack, so I am using JavaScript on a daily basis. I am also interested in the ecosystem and the community around it.",
+	// what can you contribute to the bar camp (required)
+	"whatCanIContribute": "???",
+	// if you want a T-Shirt we need your size and variant preference (optional)
+	// the following sizes are available: S, M, L, XL, 2XL, 3XL (only regular cut)
+	"tShirtSize": "M",
+	// your LinkedIn profile URL
+	"linkedin": "https://www.linkedin.com/in/lea-jell-3a3b681b5/",
+	// your website URL or other social media (optional)
+	"website": "https://leajell.de/"
+}


### PR DESCRIPTION
**I would like to register for JS CraftCamp.**

- [x] My pull request contains a JSON file `$name_or_nickname.json`
- [x] I read the `THE IMPORTANT STUFF` at [https://jscraftcamp.org/registration](https://jscraftcamp.org/registration), the JSON file follows the [template](https://github.com/jscraftcamp/website/blob/main/participants/_template.json), and contains the mandatory fields like `realName`, `githubAccountName`, `when`, `iCanTakeNotesDuringSessions`, `whatIsMyConnectionToJavascript` and `whatCanIContribute`.
- [x] If I can NOT attend, I will either send another pull request removing my JSON file or an e-mail with the subject 'UNREGISTER' to team@jscraftcamp.org
- [x] I agree that the data I enter in the registration can be used for running the event, e.g. make a name tag, count me as participant. I acknowledge that my data are public on GitHub and I agree that I will be listed on the JSCraftCamp website as a participant.
- [x] I agree that photos and videos might be taken and published (e.g. on social media) during the event.
- [x] I understand that I might NOT get a T-Shirt, because they might be in production already
- [x] I asked my company about sponsoring (see open items at: https://github.com/orgs/jscraftcamp/projects/16)

**Are you from a sponsoring company?**

- [x] Yes, I am from company Peerigon GmbH

<img src="https://media1.tenor.com/m/nb9yRj8rHo4AAAAC/excited-ah.gif" />
