### PR TITLE
feat: add pascal.json as participant

### DIFF
--- a/participants/pascal.json
+++ b/participants/pascal.json
@@ -38,7 +38,7 @@
 	//            if you have gluten free diet, please make backup plans.
 	"allergies": [],
 	// tell us a few words how JavaScript affects you (required)
-	"whatIsMyConnectionToJavascript": "I somehow ended up doing infrastructure and backend development, yet JavaScript keeps reappearing anyway.”",
+	"whatIsMyConnectionToJavascript": "I somehow ended up doing infrastructure and backend development, yet JavaScript keeps reappearing anyway.",
 	// what can you contribute to the bar camp (required)
 	"whatCanIContribute": "Good conversations about backend, Kubernetes operators, JavaScript and excitement for learning how other people solve weird problems.",
 	// if you want a T-Shirt we need your size and variant preference (optional)

--- a/participants/pascal.json
+++ b/participants/pascal.json
@@ -1,0 +1,47 @@
+// vim: ft=jsonc
+// Please provide your info in your own .json file.
+// See https://jscraftcamp.org/registration for more information
+{
+	// your real name (required by location host)
+	"realName": {
+		"givenName": "Pascal",
+		"familyName": "Neub",
+		// if you prefer to have your family name shown first (optional)
+		"placeFamilyNameFirst": false,
+		// if you do not want to show your family name on the participant list (optional)
+		"hideFamilyNameOnWebsite": false
+	},
+	// please put in the account name of the PR creator, if you sign up somebody else
+	"githubAccountName": "pas-n",
+	// your Codeberg account name (optional)
+	// "codebergAccountName": "",
+	// company name (optional)
+	"company": "ADITO Software GmbH",
+	// either both days or at least one day has to be set to true.
+	// If you cannot make one of the days, please set it to false, to allow someone else take that spot!
+	"when": {
+		// June 12th, 2026
+		"friday": true,
+		// June 13th, 2026
+		"saturday": true
+	},
+	// if you are willing to take session notes and publish them to github (required)
+	"iCanTakeNotesDuringSessions": false,
+	// your current interests (JS and in general) (required)
+	"tags": ["TypeScript", "Lit", "Bun", "Rust", "Java", "Kubernetes", "gRPC", "Security", "CI"],
+	// if you only eat vegan food (optional)
+	"vegan": false,
+	// if you only eat vegan or vegetarian food (optional)
+	"vegetarian": false,
+	// what you cannot eat or drink (optional); If you don't want to put it in here, message the organizers.
+	// IMPORTANT: we cannot guarantee that food for every diet will be available,
+	//            if you have gluten free diet, please make backup plans.
+	"allergies": [],
+	// tell us a few words how JavaScript affects you (required)
+	"whatIsMyConnectionToJavascript": "I somehow ended up doing infrastructure and backend development, yet JavaScript keeps reappearing anyway.”",
+	// what can you contribute to the bar camp (required)
+	"whatCanIContribute": "Good conversations about backend, Kubernetes operators, JavaScript and excitement for learning how other people solve weird problems.",
+	// if you want a T-Shirt we need your size and variant preference (optional)
+	// the following sizes are available: S, M, L, XL, 2XL, 3XL (only regular cut)
+	"tShirtSize": "XL"
+}


### PR DESCRIPTION
**I would like to register for JS CraftCamp.**

- [X] My pull request contains a JSON file `$name_or_nickname.json`
- [X] I read the `THE IMPORTANT STUFF` at [https://jscraftcamp.org/registration](https://jscraftcamp.org/registration), the JSON file follows the [template](https://github.com/jscraftcamp/website/blob/main/participants/_template.json), and contains the mandatory fields like `realName`, `githubAccountName`, `when`, `iCanTakeNotesDuringSessions`, `whatIsMyConnectionToJavascript` and `whatCanIContribute`.
- [X] If I can NOT attend, I will either send another pull request removing my JSON file or an e-mail with the subject 'UNREGISTER' to team@jscraftcamp.org
- [X] I agree that the data I enter in the registration can be used for running the event, e.g. make a name tag, count me as participant. I acknowledge that my data are public on GitHub and I agree that I will be listed on the JSCraftCamp website as a participant.
- [X] I agree that photos and videos might be taken and published (e.g. on social media) during the event.
- [X] I understand that I might NOT get a T-Shirt, because they might be in production already
- [ ] I asked my company about sponsoring (see open items at: https://github.com/orgs/jscraftcamp/projects/16)

**Are you from a sponsoring company?**

- [ ] Yes, I am from company ?????

**Optional GIF to show my level of excitement**

<!-- If you like to share some fun GIF with us, try to drag & drop something from giphy.com here ;) -->
