### PR TITLE
 test: enforce non-placeholder and unique githubAccountName

### DIFF
--- a/participants/jonathan_haeberle.json
+++ b/participants/jonathan_haeberle.json
@@ -5,7 +5,7 @@
     "placeFamilyNameFirst": false,
     "hideFamilyNameOnWebsite": false
   },
-  "githubAccountName": "jscraftcamp",
+  "githubAccountName": "dreampulse",
   "codebergAccountName": "",
   "company": "alm engineering",
   "when": {

--- a/participants/marcoemrich.json
+++ b/participants/marcoemrich.json
@@ -5,7 +5,7 @@
 		"placeFamilyNameFirst": false,
 		"hideFamilyNameOnWebsite": false
 	},
-	"githubAccountName": "jscraftcamp",
+	"githubAccountName": "marcoemrich",
 	"codebergAccountName": "",
 	"company": "codecentric",
 	"when": {

--- a/src/lib/participants/participants.spec.ts
+++ b/src/lib/participants/participants.spec.ts
@@ -48,4 +48,36 @@ describe('Participants', async () => {
 			});
 		});
 	}
+
+	describe('githubAccountName', async () => {
+		const participantsByFile = await Promise.all(
+			participantJsonPaths.map(async (file) => ({
+				file,
+				githubAccountName: (await parseParticipantJson(file)).githubAccountName
+			}))
+		);
+
+		it('must not be "jscraftcamp" (the placeholder from _template.json)', () => {
+			const offenders = participantsByFile.filter((p) => p.githubAccountName === 'jscraftcamp');
+
+			expect(offenders).toEqual([]);
+		});
+
+		it('must be unique across all participants', () => {
+			const firstSeenBy = new Map<string, string>();
+			const duplicates: { githubAccountName: string; files: string[] }[] = [];
+
+			for (const { file, githubAccountName } of participantsByFile) {
+				if (!githubAccountName) continue;
+				const previousFile = firstSeenBy.get(githubAccountName);
+				if (previousFile) {
+					duplicates.push({ githubAccountName, files: [previousFile, file] });
+				} else {
+					firstSeenBy.set(githubAccountName, file);
+				}
+			}
+
+			expect(duplicates).toEqual([]);
+		});
+	});
 });


### PR DESCRIPTION
- Adds a test that fails if any participant's `githubAccountName` is the `"jscraftcamp"` placeholder copied from `_template.json`.
- Adds a test that fails if two participants share the same `githubAccountName`, listing both offending files in the diff.