### PR TITLE
Add participants/henryk.json

### DIFF
--- a/participants/henryk.json
+++ b/participants/henryk.json
@@ -1,0 +1,27 @@
+{
+	"realName": {
+		"givenName": "Henry",
+		"familyName": "Kalla",
+		"placeFamilyNameFirst": false,
+		"hideFamilyNameOnWebsite": true
+	},
+	"githubAccountName": "henry-knauf",
+	"codebergAccountName": "",
+	"company": "Knauf Digital GmbH",
+	"when": {
+		"friday": true,
+		"saturday": false
+	},
+	"iCanTakeNotesDuringSessions": false,
+	"tags": ["node.js", "Nestjs", "Azure"],
+	"vegan": false,
+	"vegetarian": false,
+	"allergies": [],
+	"whatIsMyConnectionToJavascript": "JS has been with me for 2 decades and is now part of my daily work.",
+	"whatCanIContribute": "Sharing knowledge on using JS in production.",
+	"tShirtSize": "M",
+	"mastodon": "",
+	"linkedin": "",
+	"X": "",
+	"website": "https://www.knauf.com"
+}


### PR DESCRIPTION
**I would like to register Henry Kalla for JS CraftCamp.**

- [x] My pull request contains a JSON file `$name_or_nickname.json`
- [x] I read the `THE IMPORTANT STUFF` at [https://jscraftcamp.org/registration](https://jscraftcamp.org/registration), the JSON file follows the [template](https://github.com/jscraftcamp/website/blob/main/participants/_template.json), and contains the mandatory fields like `realName`, `githubAccountName`, `when`, `iCanTakeNotesDuringSessions`, `whatIsMyConnectionToJavascript` and `whatCanIContribute`.
- [x] If I can NOT attend, I will either send another pull request removing my JSON file or an e-mail with the subject 'UNREGISTER' to team@jscraftcamp.org
- [x] I agree that the data I enter in the registration can be used for running the event, e.g. make a name tag, count me as participant. I acknowledge that my data are public on GitHub and I agree that I will be listed on the JSCraftCamp website as a participant.
- [ ] I agree that photos and videos might be taken and published (e.g. on social media) during the event.
- [x] I understand that I might NOT get a T-Shirt, because they might be in production already
- [x] I asked my company about sponsoring (see open items at: https://github.com/orgs/jscraftcamp/projects/16)


