### PR TITLE
Improve registration page clarity and photography policy

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,10 @@
 **I would like to register for JS CraftCamp.**
 
 - [ ] My pull request contains a JSON file `$name_or_nickname.json`
-- [ ] I read the `THE IMPORTANT STUFF` at [https://jscraftcamp.org/registration](https://jscraftcamp.org/registration), the JSON file follows the [template](https://github.com/jscraftcamp/website/blob/main/participants/_template.json), and contains the mandatory fields like `realName`, `githubAccountName`, `when`, `iCanTakeNotesDuringSessions`, `whatIsMyConnectionToJavascript` and `whatCanIContribute`.
+- [ ] I read **Before you register** at [https://jscraftcamp.org/registration](https://jscraftcamp.org/registration), the JSON file follows the [template](https://github.com/jscraftcamp/website/blob/main/participants/_template.json), and contains the mandatory fields like `realName`, `githubAccountName`, `when`, `iCanTakeNotesDuringSessions`, `whatIsMyConnectionToJavascript` and `whatCanIContribute`.
 - [ ] If I can NOT attend, I will either send another pull request removing my JSON file or an e-mail with the subject 'UNREGISTER' to team@jscraftcamp.org
 - [ ] I agree that the data I enter in the registration can be used for running the event, e.g. make a name tag, count me as participant. I acknowledge that my data are public on GitHub and I agree that I will be listed on the JSCraftCamp website as a participant.
-- [ ] I agree that photos and videos might be taken and published (e.g. on social media) during the event.
+- [ ] I understand that photos and videos may be taken during the event. If I do not want to appear in **published/released** event photos, I will wear a **red dot clearly visible next to my nametag** (provided at the event) and try to avoid being in shots when I see a photographer.
 - [ ] I understand that I might NOT get a T-Shirt, because they might be in production already
 - [ ] I asked my company about sponsoring (see open items at: https://github.com/orgs/jscraftcamp/projects/16)
 

--- a/src/lib/components/CtaLink.svelte
+++ b/src/lib/components/CtaLink.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+	import { cn } from '$lib/utils/cn';
+
+	type Variant = 'register' | 'muted';
+
+	interface Props {
+		href?: string;
+		variant?: Variant;
+		external?: boolean;
+		class?: string;
+		children?: import('svelte').Snippet;
+	}
+
+	let {
+		href,
+		variant = 'register',
+		external = false,
+		class: className = '',
+		children
+	}: Props = $props();
+
+	const baseClass =
+		'inline-block rounded-full px-6 py-2.5 text-sm font-semibold no-underline transition-colors';
+
+	const variantClass: Record<Variant, string> = {
+		register: 'bg-emerald-700 text-white hover:bg-emerald-800 hover:text-white',
+		muted: 'bg-stone-600/80 text-stone-200'
+	};
+</script>
+
+{#if href}
+	<a
+		{href}
+		class={cn(baseClass, variantClass[variant], className)}
+		rel={external ? 'external' : undefined}
+		target={external ? '_blank' : undefined}
+	>
+		{@render children?.()}
+	</a>
+{:else}
+	<span class={cn(baseClass, variantClass[variant], className)}>
+		{@render children?.()}
+	</span>
+{/if}

--- a/src/lib/components/HeaderCard.svelte
+++ b/src/lib/components/HeaderCard.svelte
@@ -8,6 +8,7 @@
 		getShortYear,
 		getYear
 	} from '$lib/config/event';
+	import CtaLink from '$lib/components/CtaLink.svelte';
 	import Card from '$lib/layout/Card.svelte';
 	import { cn } from '$lib/utils/cn';
 
@@ -96,26 +97,15 @@
 			<!-- Registration button -->
 			<div class="mt-4">
 				{#if registrationState === 'open'}
-					<a
-						href="/registration"
-						class="inline-block rounded-full bg-emerald-700 px-6 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-emerald-800"
-					>
-						Register now
-					</a>
+					<CtaLink href="/registration">Register now</CtaLink>
 				{:else if registrationState === 'not-yet'}
-					<span
-						class="inline-block rounded-full bg-stone-600/80 px-6 py-2.5 text-sm font-semibold text-stone-200"
-					>
+					<CtaLink variant="muted">
 						Registration opens in {daysUntilRegistration} day{daysUntilRegistration === 1
 							? ''
 							: 's'}
-					</span>
+					</CtaLink>
 				{:else}
-					<span
-						class="inline-block rounded-full bg-stone-600/80 px-6 py-2.5 text-sm font-semibold text-stone-200"
-					>
-						Registration closed
-					</span>
+					<CtaLink variant="muted">Registration closed</CtaLink>
 				{/if}
 			</div>
 		</div>

--- a/src/routes/registration/+page.svelte
+++ b/src/routes/registration/+page.svelte
@@ -1,94 +1,184 @@
 <script lang="ts">
 	import { base } from '$app/paths';
 	import { socialLinks } from '$lib/config/social';
+	import { eventConfig, getRegistrationState } from '$lib/config/event';
 	import Card from '$lib/layout/Card.svelte';
 	import Content from '$lib/layout/Content.svelte';
 	import PageLayout from '$lib/layout/PageLayout.svelte';
 	import RegistrationTemplate from '../../../participants/_template.json?raw';
+
+	const registrationState = getRegistrationState();
+	const githubNewParticipantUrl =
+		'https://github.com/jscraftcamp/website/new/main/participants';
+	const templateUrl =
+		'https://github.com/jscraftcamp/website/blob/main/participants/_template.json';
 </script>
 
 <PageLayout>
 	<Content>
 		<h1>Registration</h1>
-		<Card>
-			<h2>Registration process</h2>
-			<p>
-				Out of these JSON files, the <a href="{base}/participants/">/participants</a> page will be generated.
-			</p>
 
-			<p>
-				<sup>1</sup>
-				<a href="https://www.npmjs.com/package/jsonc-parser"
-					>JSONC is JSON with JavaScript style comments</a
-				>.
-				<br />
-				<sup>2</sup> Click
-				<a href="https://github.com/jscraftcamp/website/new/main/participants"
-					>this link to start the process on the github page</a
-				>
-				to create the JSONC file in the repo. Make sure you are logged in to github.
-			</p>
+		<Card>
+			{#if registrationState === 'open'}
+				<h2>Registration is open</h2>
+				<p>
+					Welcome! To register for JSCraftCamp, open a pull request on GitHub that adds your
+					<code>participants/yourname.json</code> file. After your PR is merged, you will appear on the
+					<a href="{base}/participants/">participants page</a>.
+				</p>
+				<p>
+					<a
+						href={githubNewParticipantUrl}
+						rel="external"
+						target="_blank"
+						class="register-cta inline-block rounded-full bg-emerald-700 px-6 py-2.5 text-sm font-semibold no-underline transition-colors hover:bg-emerald-800"
+					>
+						Register on GitHub
+					</a>
+				</p>
+			{:else if registrationState === 'not-yet' && eventConfig.registrationOpensAt}
+				<h2>Registration opens soon</h2>
+				<p>
+					Registration opens on
+					<strong>{eventConfig.registrationOpensAt.toLocaleDateString()}</strong>. Get your GitHub
+					account ready and check back then.
+				</p>
+				<p>
+					When registration opens, you will register by opening a pull request that adds your
+					<code>participants/yourname.json</code> file. The public
+					<a href="{base}/participants/">participants list</a> is built from those files.
+				</p>
+			{:else}
+				<h2>Registration is closed</h2>
+				<p>
+					Registration closed on
+					<strong>{eventConfig.registrationClosesAt?.toLocaleDateString() ?? 'the deadline'}</strong
+					>. See who is coming on the
+					<a href="{base}/participants/">participants page</a>.
+				</p>
+				<p>
+					Need to change your registration? Contact us at
+					<a href="mailto:team@jscraftcamp.org">team@jscraftcamp.org</a>.
+				</p>
+			{/if}
 		</Card>
 
 		<Card>
-			<h2>The important stuff</h2>
+			<h2>Before you register</h2>
 			<ul>
 				<li>
-					Please put in your <strong>real name</strong>; Location host will check it at the entrance
+					<strong>Real name:</strong> Use your real name in the JSON file. The location host will check it
+					at the entrance.
 				</li>
 				<li>
-					If you don't want to put in allergies or anything else, drop us a message at <a
-						href={socialLinks.discord}
-						rel="external">Discord</a
-					>
-					or <a href="mailto:team@jscraftcamp.org">team@jscraftcamp.org</a>.
+					<strong>Public data:</strong> Your pull request and participant data are public on GitHub. After
+					merge, you will be listed on the
+					<a href="{base}/participants/">participants page</a>.
 				</li>
 				<li>
-					We will try our best to fulfil your dietary requirements, but we cannot guarantee
-					anything. We will post the ordered food in the issues, so you can check if you need to
-					bring something for yourself.
+					<strong>Dietary requirements:</strong> We try our best to fulfil your needs, but we cannot guarantee
+					everything. We post ordered food in GitHub issues so you can check whether you need to bring
+					something yourself.
 				</li>
 				<li>
-					If you need help <a href={socialLinks.discord} rel="external">reach out</a>! You will
-					learn some git for free.
+					<strong>Allergies and sensitive info:</strong> You do not have to put allergies in your JSON file.
+					If you prefer not to, message us on
+					<a href={socialLinks.discord} rel="external">Discord</a>
+					or
+					<a href="mailto:team@jscraftcamp.org">team@jscraftcamp.org</a>.
 				</li>
 				<li>
-					Please read the JSON comments, they should explain every field, and if you have questions <a
-						href="mailto:team@jscraftcamp.org">reach out</a
-					>.
+					<strong>Need help?</strong>
+					<a href={socialLinks.discord} rel="external">Reach out on Discord</a> — we are happy to help with
+					Git and pull requests.
 				</li>
 				<li>
-					If you have any improvement suggestions, please <a href="mailto:team@jscraftcamp.org"
-						>let us know</a
-					>.
+					<strong>JSON fields:</strong> Read the comments in the
+					<a href={templateUrl} rel="external">registration template</a>. They explain every field. Questions?
+					<a href="mailto:team@jscraftcamp.org">Contact the team</a>.
+				</li>
+				<li>
+					<strong>Suggestions?</strong>
+					<a href="mailto:team@jscraftcamp.org">Let us know</a> if you have ideas to improve registration.
 				</li>
 			</ul>
 		</Card>
 
 		<Card>
-			<h2>The JSON format</h2>
-			<p>Your registration as JSON file should be in the following format to pass the tests:</p>
-			<pre class="template">{RegistrationTemplate}</pre>
-		</Card>
-
-		<Card>
-			<h2>Validation for your JSON file</h2>
+			<h2>Photography and red dots</h2>
 			<p>
-				To test if your JSON file is a valid registration you can run <code>pnpm run test</code>
-				(more details about this are in the
-				<a href="https://github.com/jscraftcamp/website/tree/main/README.md" rel="external"
-					><code>README.md</code></a
-				> file). Invalid registrations will be rejected. If you need any help with registration, don't
-				hesitate to contact one of the team.
+				Photographers may take photos and videos during the event for documentation and social media. See
+				<a href="{base}/archive/2025/photos/">photos from past events</a> for examples.
+			</p>
+			<p>
+				If you do <strong>not</strong> want to appear in <strong>published or released</strong> event photos,
+				we provide <span class="red-dot" aria-hidden="true"></span>
+				<strong>red dots at check-in</strong>. Wear one
+				<strong>clearly visible next to your nametag</strong> so photographers and others can see your preference.
+			</p>
+			<p>
+				A red dot signals that you do not consent to being in published event photos. Photographers and the
+				team are asked to respect this.
+			</p>
+			<p>
+				If you want to avoid being in photos, when you notice a photographer aiming in your direction, try to
+				<strong>look away</strong>, <strong>step out of the frame</strong>, or <strong>turn aside</strong>.
+				Red dots help communicate your preference, but we cannot guarantee that every incidental photo is
+				avoided.
+			</p>
+			<p>
+				Using a red dot for published photos does <strong>not</strong> prevent you from registering for the
+				event.
 			</p>
 		</Card>
 
 		<Card>
-			<h2>Process to unregister</h2>
+			<h2>How to register</h2>
+			<ol class="steps">
+				<li>Read <strong>Before you register</strong> and <strong>Photography and red dots</strong> on this page.</li>
+				<li>Log in to <a href="https://github.com" rel="external">GitHub</a>.</li>
+				<li>
+					<a href={githubNewParticipantUrl} rel="external">Create a new file</a> in the
+					<code>participants/</code> folder. Name it <code>yourgithubusername.json</code> (use your GitHub
+					username).
+				</li>
+				<li>
+					Copy the <a href={templateUrl} rel="external">registration template</a>, fill in the required fields,
+					and adjust optional fields. The file may include comments (
+					<a href="https://www.npmjs.com/package/jsonc-parser" rel="external">JSONC</a>).
+				</li>
+				<li>Open a pull request and complete the PR checklist.</li>
+				<li>
+					After your PR is merged, you appear on the
+					<a href="{base}/participants/">participants page</a>.
+				</li>
+			</ol>
+		</Card>
+
+		<Card>
+			<h2>JSON format</h2>
+			<p>Your registration JSON file must match this format to pass validation:</p>
+			<pre class="template">{RegistrationTemplate}</pre>
+		</Card>
+
+		<Card>
+			<h2>Validation</h2>
 			<p>
-				If you registered previously and at some point find out you can't make it to the
-				JSCraftCamp, please let us know. Either unregister by writing another pull request, write an
-				issue or contact us at <a href="mailto:team@jscraftcamp.org">team@jscraftcamp.org</a>.
+				To check your JSON locally, run <code>pnpm run test</code> (see the
+				<a href="https://github.com/jscraftcamp/website/tree/main/README.md" rel="external"
+					><code>README.md</code></a
+				> for details). Invalid registrations are rejected by our automated checks. If you need help, contact
+				the team at <a href="mailto:team@jscraftcamp.org">team@jscraftcamp.org</a>.
+			</p>
+		</Card>
+
+		<Card>
+			<h2>Cancel your registration</h2>
+			<p>
+				If you registered but can no longer attend, please let us know. You can cancel by opening another pull
+				request that removes your JSON file, by opening a GitHub issue, or by emailing
+				<a href="mailto:team@jscraftcamp.org">team@jscraftcamp.org</a> with the subject
+				<code>UNREGISTER</code>.
 			</p>
 		</Card>
 	</Content>
@@ -98,5 +188,39 @@
 	.template {
 		overflow-x: auto;
 		max-width: 100%;
+	}
+
+	.steps {
+		list-style: decimal;
+		padding-left: 1.5rem;
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+	}
+
+	.steps li {
+		padding-left: 0.5rem;
+	}
+
+	.steps li::marker {
+		color: var(--color-primary-500);
+	}
+
+	.red-dot {
+		display: inline-block;
+		width: 0.75rem;
+		height: 0.75rem;
+		border-radius: 9999px;
+		background-color: #dc2626;
+		vertical-align: middle;
+		margin: 0 0.15rem;
+	}
+
+	.register-cta {
+		color: white;
+	}
+
+	.register-cta:hover {
+		color: white;
 	}
 </style>

--- a/src/routes/registration/+page.svelte
+++ b/src/routes/registration/+page.svelte
@@ -32,6 +32,10 @@
 				<p>
 					<CtaLink href={githubNewParticipantUrl} external>Register on GitHub</CtaLink>
 				</p>
+				<p>
+					Already registered? To update your details, open another pull request with changes to your
+					JSON file. To cancel, see <strong>Cancel your registration</strong> below.
+				</p>
 			{:else if registrationState === 'not-yet' && eventConfig.registrationOpensAt}
 				<h2>Registration opens soon</h2>
 				<p>
@@ -53,8 +57,8 @@
 					<a href="{base}/participants/">participants page</a>.
 				</p>
 				<p>
-					Need to change your registration? Contact us at
-					<a href="mailto:team@jscraftcamp.org">team@jscraftcamp.org</a>.
+					Already registered and need to change or cancel? See
+					<strong>Cancel your registration</strong> below.
 				</p>
 			{/if}
 		</Card>

--- a/src/routes/registration/+page.svelte
+++ b/src/routes/registration/+page.svelte
@@ -162,8 +162,8 @@
 					<a href={githubNewParticipantUrl} rel="external">Create a new file</a> in the
 					<code>participants/</code> folder (opens with the registration template pre-filled).
 					Rename
-					<code>your_name.json</code> to <code>yourgithubusername.json</code> (with your actual GitHub
-					username) or <code>firstname_lastname.json</code>
+					<code>your_name.json</code> to <code>yourgithubusername.json</code> (with your actual
+					GitHub username) or <code>firstname_lastname.json</code>
 				</li>
 				<li>
 					Copy the <a href={templateUrl} rel="external">registration template</a>, fill in the
@@ -239,5 +239,4 @@
 		vertical-align: middle;
 		margin: 0 0.15rem;
 	}
-
 </style>

--- a/src/routes/registration/+page.svelte
+++ b/src/routes/registration/+page.svelte
@@ -2,6 +2,7 @@
 	import { base } from '$app/paths';
 	import { socialLinks } from '$lib/config/social';
 	import { eventConfig, getRegistrationState } from '$lib/config/event';
+	import CtaLink from '$lib/components/CtaLink.svelte';
 	import Card from '$lib/layout/Card.svelte';
 	import Content from '$lib/layout/Content.svelte';
 	import PageLayout from '$lib/layout/PageLayout.svelte';
@@ -29,14 +30,7 @@
 					<a href="{base}/participants/">participants page</a>.
 				</p>
 				<p>
-					<a
-						href={githubNewParticipantUrl}
-						rel="external"
-						target="_blank"
-						class="register-cta inline-block rounded-full bg-emerald-700 px-6 py-2.5 text-sm font-semibold no-underline transition-colors hover:bg-emerald-800"
-					>
-						Register on GitHub
-					</a>
+					<CtaLink href={githubNewParticipantUrl} external>Register on GitHub</CtaLink>
 				</p>
 			{:else if registrationState === 'not-yet' && eventConfig.registrationOpensAt}
 				<h2>Registration opens soon</h2>
@@ -164,7 +158,8 @@
 					<a href={githubNewParticipantUrl} rel="external">Create a new file</a> in the
 					<code>participants/</code> folder (opens with the registration template pre-filled).
 					Rename
-					<code>your_name.json</code> to <code>yourgithubusername.json</code> using your GitHub username.
+					<code>your_name.json</code> to <code>yourgithubusername.json</code> (with your actual GitHub
+					username) or <code>firstname_lastname.json</code>
 				</li>
 				<li>
 					Copy the <a href={templateUrl} rel="external">registration template</a>, fill in the
@@ -241,11 +236,4 @@
 		margin: 0 0.15rem;
 	}
 
-	.register-cta {
-		color: white;
-	}
-
-	.register-cta:hover {
-		color: white;
-	}
 </style>

--- a/src/routes/registration/+page.svelte
+++ b/src/routes/registration/+page.svelte
@@ -175,8 +175,8 @@
 				<a href="https://github.com/jscraftcamp/website/tree/main/README.md" rel="external"
 					><code>README.md</code></a
 				>
-				for details). Invalid registrations are rejected by our automated checks. If you need help,
-				contact the team at <a href="mailto:team@jscraftcamp.org">team@jscraftcamp.org</a>.
+				for details). Invalid registrations are rejected by our automated checks. If you need help, contact
+				the team at <a href="mailto:team@jscraftcamp.org">team@jscraftcamp.org</a>.
 			</p>
 		</Card>
 

--- a/src/routes/registration/+page.svelte
+++ b/src/routes/registration/+page.svelte
@@ -8,7 +8,8 @@
 	import RegistrationTemplate from '../../../participants/_template.json?raw';
 
 	const registrationState = getRegistrationState();
-	const githubNewParticipantUrl = 'https://github.com/jscraftcamp/website/new/main/participants';
+	const githubNewParticipantFilename = 'your_name.json';
+	const githubNewParticipantUrl = `https://github.com/jscraftcamp/website/new/main/participants?filename=${encodeURIComponent(githubNewParticipantFilename)}&value=${encodeURIComponent(RegistrationTemplate)}`;
 	const templateUrl =
 		'https://github.com/jscraftcamp/website/blob/main/participants/_template.json';
 </script>
@@ -21,7 +22,8 @@
 			{#if registrationState === 'open'}
 				<h2>Registration is open</h2>
 				<p>
-					Welcome! To register for JSCraftCamp, open a pull request on GitHub that adds your
+					Welcome and thank you for your interest in joining our event as a participant! To register
+					for JSCraftCamp, open a pull request on GitHub that adds your
 					<code>participants/yourname.json</code> file. After your PR is merged, you will appear on
 					the
 					<a href="{base}/participants/">participants page</a>.
@@ -64,6 +66,19 @@
 		</Card>
 
 		<Card>
+			<h2>Why are you making us do this?</h2>
+			<p>
+				JSCraftCamp is free and open to developers of any skill level. Registration via pull request
+				is intentional: we want people who register to put in a little effort up front, so we keep
+				no-show rates low — a common challenge at free events.
+			</p>
+			<p>
+				In practice, you “pay” with your time instead of money. Opening a PR shows us your
+				commitment and helps us plan food, space, and the participant list with more confidence.
+			</p>
+		</Card>
+
+		<Card>
 			<h2>Before you register</h2>
 			<ul>
 				<li>
@@ -94,8 +109,8 @@
 				</li>
 				<li>
 					<strong>JSON fields:</strong> Read the comments in the
-					<a href={templateUrl} rel="external">registration template</a>. They explain every field.
-					Questions?
+					<a href={templateUrl} rel="external">registration template</a>. They should explain every
+					field. If something is unclear, please tell us! Questions?
 					<a href="mailto:team@jscraftcamp.org">Contact the team</a>.
 				</li>
 				<li>
@@ -140,14 +155,16 @@
 			<h2>How to register</h2>
 			<ol class="steps">
 				<li>
-					Read <strong>Before you register</strong> and <strong>Photography and red dots</strong> on
-					this page.
+					Read <strong>Why are you making us do this?</strong>,
+					<strong>Before you register</strong>, and <strong>Photography and red dots</strong> on this
+					page.
 				</li>
 				<li>Log in to <a href="https://github.com" rel="external">GitHub</a>.</li>
 				<li>
 					<a href={githubNewParticipantUrl} rel="external">Create a new file</a> in the
-					<code>participants/</code> folder. Name it <code>yourgithubusername.json</code> (use your GitHub
-					username).
+					<code>participants/</code> folder (opens with the registration template pre-filled).
+					Rename
+					<code>your_name.json</code> to <code>yourgithubusername.json</code> using your GitHub username.
 				</li>
 				<li>
 					Copy the <a href={templateUrl} rel="external">registration template</a>, fill in the

--- a/src/routes/registration/+page.svelte
+++ b/src/routes/registration/+page.svelte
@@ -8,8 +8,7 @@
 	import RegistrationTemplate from '../../../participants/_template.json?raw';
 
 	const registrationState = getRegistrationState();
-	const githubNewParticipantUrl =
-		'https://github.com/jscraftcamp/website/new/main/participants';
+	const githubNewParticipantUrl = 'https://github.com/jscraftcamp/website/new/main/participants';
 	const templateUrl =
 		'https://github.com/jscraftcamp/website/blob/main/participants/_template.json';
 </script>
@@ -23,7 +22,8 @@
 				<h2>Registration is open</h2>
 				<p>
 					Welcome! To register for JSCraftCamp, open a pull request on GitHub that adds your
-					<code>participants/yourname.json</code> file. After your PR is merged, you will appear on the
+					<code>participants/yourname.json</code> file. After your PR is merged, you will appear on
+					the
 					<a href="{base}/participants/">participants page</a>.
 				</p>
 				<p>
@@ -67,34 +67,35 @@
 			<h2>Before you register</h2>
 			<ul>
 				<li>
-					<strong>Real name:</strong> Use your real name in the JSON file. The location host will check it
-					at the entrance.
+					<strong>Real name:</strong> Use your real name in the JSON file. The location host will check
+					it at the entrance.
 				</li>
 				<li>
-					<strong>Public data:</strong> Your pull request and participant data are public on GitHub. After
-					merge, you will be listed on the
+					<strong>Public data:</strong> Your pull request and participant data are public on GitHub.
+					After merge, you will be listed on the
 					<a href="{base}/participants/">participants page</a>.
 				</li>
 				<li>
-					<strong>Dietary requirements:</strong> We try our best to fulfil your needs, but we cannot guarantee
-					everything. We post ordered food in GitHub issues so you can check whether you need to bring
-					something yourself.
+					<strong>Dietary requirements:</strong> We try our best to fulfil your needs, but we cannot
+					guarantee everything. We post ordered food in GitHub issues so you can check whether you need
+					to bring something yourself.
 				</li>
 				<li>
-					<strong>Allergies and sensitive info:</strong> You do not have to put allergies in your JSON file.
-					If you prefer not to, message us on
+					<strong>Allergies and sensitive info:</strong> You do not have to put allergies in your
+					JSON file. If you prefer not to, message us on
 					<a href={socialLinks.discord} rel="external">Discord</a>
 					or
 					<a href="mailto:team@jscraftcamp.org">team@jscraftcamp.org</a>.
 				</li>
 				<li>
 					<strong>Need help?</strong>
-					<a href={socialLinks.discord} rel="external">Reach out on Discord</a> — we are happy to help with
-					Git and pull requests.
+					<a href={socialLinks.discord} rel="external">Reach out on Discord</a> — we are happy to help
+					with Git and pull requests.
 				</li>
 				<li>
 					<strong>JSON fields:</strong> Read the comments in the
-					<a href={templateUrl} rel="external">registration template</a>. They explain every field. Questions?
+					<a href={templateUrl} rel="external">registration template</a>. They explain every field.
+					Questions?
 					<a href="mailto:team@jscraftcamp.org">Contact the team</a>.
 				</li>
 				<li>
@@ -107,35 +108,41 @@
 		<Card>
 			<h2>Photography and red dots</h2>
 			<p>
-				Photographers may take photos and videos during the event for documentation and social media. See
+				Photographers may take photos and videos during the event for documentation and social
+				media. See
 				<a href="{base}/archive/2025/photos/">photos from past events</a> for examples.
 			</p>
 			<p>
-				If you do <strong>not</strong> want to appear in <strong>published or released</strong> event photos,
-				we provide <span class="red-dot" aria-hidden="true"></span>
+				If you do <strong>not</strong> want to appear in <strong>published or released</strong>
+				event photos, we provide <span class="red-dot" aria-hidden="true"></span>
 				<strong>red dots at check-in</strong>. Wear one
-				<strong>clearly visible next to your nametag</strong> so photographers and others can see your preference.
+				<strong>clearly visible next to your nametag</strong> so photographers and others can see your
+				preference.
 			</p>
 			<p>
-				A red dot signals that you do not consent to being in published event photos. Photographers and the
-				team are asked to respect this.
+				A red dot signals that you do not consent to being in published event photos. Photographers
+				and the team are asked to respect this.
 			</p>
 			<p>
-				If you want to avoid being in photos, when you notice a photographer aiming in your direction, try to
-				<strong>look away</strong>, <strong>step out of the frame</strong>, or <strong>turn aside</strong>.
-				Red dots help communicate your preference, but we cannot guarantee that every incidental photo is
-				avoided.
+				If you want to avoid being in photos, when you notice a photographer aiming in your
+				direction, try to
+				<strong>look away</strong>, <strong>step out of the frame</strong>, or
+				<strong>turn aside</strong>. Red dots help communicate your preference, but we cannot
+				guarantee that every incidental photo is avoided.
 			</p>
 			<p>
-				Using a red dot for published photos does <strong>not</strong> prevent you from registering for the
-				event.
+				Using a red dot for published photos does <strong>not</strong> prevent you from registering for
+				the event.
 			</p>
 		</Card>
 
 		<Card>
 			<h2>How to register</h2>
 			<ol class="steps">
-				<li>Read <strong>Before you register</strong> and <strong>Photography and red dots</strong> on this page.</li>
+				<li>
+					Read <strong>Before you register</strong> and <strong>Photography and red dots</strong> on
+					this page.
+				</li>
 				<li>Log in to <a href="https://github.com" rel="external">GitHub</a>.</li>
 				<li>
 					<a href={githubNewParticipantUrl} rel="external">Create a new file</a> in the
@@ -143,8 +150,8 @@
 					username).
 				</li>
 				<li>
-					Copy the <a href={templateUrl} rel="external">registration template</a>, fill in the required fields,
-					and adjust optional fields. The file may include comments (
+					Copy the <a href={templateUrl} rel="external">registration template</a>, fill in the
+					required fields, and adjust optional fields. The file may include comments (
 					<a href="https://www.npmjs.com/package/jsonc-parser" rel="external">JSONC</a>).
 				</li>
 				<li>Open a pull request and complete the PR checklist.</li>
@@ -167,16 +174,17 @@
 				To check your JSON locally, run <code>pnpm run test</code> (see the
 				<a href="https://github.com/jscraftcamp/website/tree/main/README.md" rel="external"
 					><code>README.md</code></a
-				> for details). Invalid registrations are rejected by our automated checks. If you need help, contact
-				the team at <a href="mailto:team@jscraftcamp.org">team@jscraftcamp.org</a>.
+				>
+				for details). Invalid registrations are rejected by our automated checks. If you need help,
+				contact the team at <a href="mailto:team@jscraftcamp.org">team@jscraftcamp.org</a>.
 			</p>
 		</Card>
 
 		<Card>
 			<h2>Cancel your registration</h2>
 			<p>
-				If you registered but can no longer attend, please let us know. You can cancel by opening another pull
-				request that removes your JSON file, by opening a GitHub issue, or by emailing
+				If you registered but can no longer attend, please let us know. You can cancel by opening
+				another pull request that removes your JSON file, by opening a GitHub issue, or by emailing
 				<a href="mailto:team@jscraftcamp.org">team@jscraftcamp.org</a> with the subject
 				<code>UNREGISTER</code>.
 			</p>


### PR DESCRIPTION
## Summary

- Restructures the registration page for attendees: status banner (open / soon / closed), **Before you register**, **Photography and red dots**, numbered **How to register** steps, then JSON format, validation, and cancel registration.
- Adds guidance on red dots at check-in (visible next to nametag), opting out of published/released photos, and practical tips to avoid being photographed.
- Aligns the registration PR template: references **Before you register** instead of “THE IMPORTANT STUFF”, and rewords the photo checkbox to match the red-dot opt-out for published photos.
