### PR TITLE
Add participants/david-craftcloud.json

### DIFF
--- a/participants/david-craftcloud.json
+++ b/participants/david-craftcloud.json
@@ -1,0 +1,27 @@
+{
+	"realName": {
+		"givenName": "David",
+		"familyName": "Farkas",
+		"placeFamilyNameFirst": false,
+		"hideFamilyNameOnWebsite": false
+	},
+	"githubAccountName": "david-craftcloud",
+	"codebergAccountName": "",
+	"company": "All3DP GmbH",
+	"when": {
+		"friday": true,
+		"saturday": false
+	},
+	"iCanTakeNotesDuringSessions": false,
+	"tags": ["TypeScript", "Nestjs", "Claude"],
+	"vegan": false,
+	"vegetarian": false,
+	"allergies": [],
+	"whatIsMyConnectionToJavascript": "It is my primary programming language for work and personal stuff",
+	"whatCanIContribute": "Sharing development experience",
+	"tShirtSize": "L",
+	"mastodon": "",
+	"linkedin": "",
+	"X": "",
+	"website": "https://craftcloud3d.com"
+}


### PR DESCRIPTION
**I would like to register for JS CraftCamp.**

- [x] My pull request contains a JSON file `$name_or_nickname.json`
- [x] I read **Before you register** at [https://jscraftcamp.org/registration](https://jscraftcamp.org/registration), the JSON file follows the [template](https://github.com/jscraftcamp/website/blob/main/participants/_template.json), and contains the mandatory fields like `realName`, `githubAccountName`, `when`, `iCanTakeNotesDuringSessions`, `whatIsMyConnectionToJavascript` and `whatCanIContribute`.
- [x] If I can NOT attend, I will either send another pull request removing my JSON file or an e-mail with the subject 'UNREGISTER' to team@jscraftcamp.org
- [x] I agree that the data I enter in the registration can be used for running the event, e.g. make a name tag, count me as participant. I acknowledge that my data are public on GitHub and I agree that I will be listed on the JSCraftCamp website as a participant.
- [x] I understand that photos and videos may be taken during the event. If I do not want to appear in **published/released** event photos, I will wear a **red dot clearly visible next to my nametag** (provided at the event) and try to avoid being in shots when I see a photographer.
- [x] I understand that I might NOT get a T-Shirt, because they might be in production already
- [x] I asked my company about sponsoring (see open items at: https://github.com/orgs/jscraftcamp/projects/16)
