### PR TITLE
Catch JSON syntax errors in participant registration tests

### DIFF
--- a/participants/ariadne.json
+++ b/participants/ariadne.json
@@ -27,7 +27,7 @@
     "Vanilla JS",
     "Elixir",
     "Postgres"
-  ]
+  ],
   // if you only eat vegan food (optional)
   "vegan": false,
   // if you only eat vegan or vegetarian food (optional)

--- a/participants/dan.json
+++ b/participants/dan.json
@@ -26,7 +26,7 @@
 	// if you are willing to take session notes and publish them to github (required)
 	"iCanTakeNotesDuringSessions": true,
 	// your current interests (JS and in general) (required)
-	"tags": ["Angular", "NestJS", "Vercel", "Next.js" "TypeScript", "AI", "Claude Code"],
+	"tags": ["Angular", "NestJS", "Vercel", "Next.js", "TypeScript", "AI", "Claude Code"],
 	// if you only eat vegan food (optional)
 	"vegan": false,
 	// if you only eat vegan or vegetarian food (optional)

--- a/src/lib/participants/participants.spec.ts
+++ b/src/lib/participants/participants.spec.ts
@@ -1,32 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { readdir, readFile } from 'node:fs/promises';
-import { getLocation, parse, printParseErrorCode, type ParseError } from 'jsonc-parser';
+import { readdir } from 'node:fs/promises';
 import { loadParticipantJsonFilePaths, parseParticipantJson } from './participants';
 import { PARTICIPANTS_DIRECTORY } from './participant-schema';
-
-const JSONC_PARSE_OPTIONS = { allowTrailingComma: true } as const;
-
-function formatParseErrors(text: string, errors: ParseError[]): string {
-	return errors
-		.map((error) => {
-			const location = getLocation(text, error.offset);
-			const path = location.path.length > 0 ? location.path.join('.') : 'root';
-			return `${path}: ${printParseErrorCode(error.error)}`;
-		})
-		.join(', ');
-}
-
-async function assertValidParticipantJson(filePath: string) {
-	const text = await readFile(filePath, 'utf-8');
-	const parseErrors: ParseError[] = [];
-	parse(text, parseErrors, JSONC_PARSE_OPTIONS);
-
-	if (parseErrors.length > 0) {
-		throw new Error(`JSON syntax error in '${filePath}': ${formatParseErrors(text, parseErrors)}`);
-	}
-
-	return parseParticipantJson(filePath);
-}
 
 describe('Participants', async () => {
 	const folderContent = await readdir(PARTICIPANTS_DIRECTORY, {
@@ -63,7 +38,7 @@ describe('Participants', async () => {
 			it(`should parse '${participantFile}' without syntax or validation error`, async () => {
 				let error: string | null = null;
 				try {
-					await assertValidParticipantJson(participantFile);
+					await parseParticipantJson(participantFile);
 				} catch (err) {
 					error = (err as Error).message;
 					console.error(error);

--- a/src/lib/participants/participants.spec.ts
+++ b/src/lib/participants/participants.spec.ts
@@ -1,7 +1,39 @@
 import { describe, it, expect } from 'vitest';
-import { readdir } from 'node:fs/promises';
+import { readdir, readFile } from 'node:fs/promises';
+import {
+	getLocation,
+	parse,
+	printParseErrorCode,
+	type ParseError
+} from 'jsonc-parser';
 import { loadParticipantJsonFilePaths, parseParticipantJson } from './participants';
 import { PARTICIPANTS_DIRECTORY } from './participant-schema';
+
+const JSONC_PARSE_OPTIONS = { allowTrailingComma: true } as const;
+
+function formatParseErrors(text: string, errors: ParseError[]): string {
+	return errors
+		.map((error) => {
+			const location = getLocation(text, error.offset);
+			const path = location.path.length > 0 ? location.path.join('.') : 'root';
+			return `${path}: ${printParseErrorCode(error.error)}`;
+		})
+		.join(', ');
+}
+
+async function assertValidParticipantJson(filePath: string) {
+	const text = await readFile(filePath, 'utf-8');
+	const parseErrors: ParseError[] = [];
+	parse(text, parseErrors, JSONC_PARSE_OPTIONS);
+
+	if (parseErrors.length > 0) {
+		throw new Error(
+			`JSON syntax error in '${filePath}': ${formatParseErrors(text, parseErrors)}`
+		);
+	}
+
+	return parseParticipantJson(filePath);
+}
 
 describe('Participants', async () => {
 	const folderContent = await readdir(PARTICIPANTS_DIRECTORY, {
@@ -35,10 +67,10 @@ describe('Participants', async () => {
 
 	for (const participantFile of participantJsonPaths) {
 		describe('parseParticipants', async () => {
-			it(`should parse '${participantFile}' without validation error`, async () => {
+			it(`should parse '${participantFile}' without syntax or validation error`, async () => {
 				let error: string | null = null;
 				try {
-					await parseParticipantJson(participantFile);
+					await assertValidParticipantJson(participantFile);
 				} catch (err) {
 					error = (err as Error).message;
 					console.error(error);

--- a/src/lib/participants/participants.spec.ts
+++ b/src/lib/participants/participants.spec.ts
@@ -1,11 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { readdir, readFile } from 'node:fs/promises';
-import {
-	getLocation,
-	parse,
-	printParseErrorCode,
-	type ParseError
-} from 'jsonc-parser';
+import { getLocation, parse, printParseErrorCode, type ParseError } from 'jsonc-parser';
 import { loadParticipantJsonFilePaths, parseParticipantJson } from './participants';
 import { PARTICIPANTS_DIRECTORY } from './participant-schema';
 
@@ -27,9 +22,7 @@ async function assertValidParticipantJson(filePath: string) {
 	parse(text, parseErrors, JSONC_PARSE_OPTIONS);
 
 	if (parseErrors.length > 0) {
-		throw new Error(
-			`JSON syntax error in '${filePath}': ${formatParseErrors(text, parseErrors)}`
-		);
+		throw new Error(`JSON syntax error in '${filePath}': ${formatParseErrors(text, parseErrors)}`);
 	}
 
 	return parseParticipantJson(filePath);

--- a/src/lib/participants/participants.ts
+++ b/src/lib/participants/participants.ts
@@ -4,12 +4,7 @@ import {
 	type Participant,
 	PARTICIPANTS_DIRECTORY
 } from '$lib/participants/participant-schema';
-import {
-	getLocation,
-	parse,
-	printParseErrorCode,
-	type ParseError
-} from 'jsonc-parser';
+import { getLocation, parse, printParseErrorCode, type ParseError } from 'jsonc-parser';
 import { join } from 'node:path';
 
 const JSONC_PARSE_OPTIONS = { allowTrailingComma: true } as const;

--- a/src/lib/participants/participants.ts
+++ b/src/lib/participants/participants.ts
@@ -4,8 +4,25 @@ import {
 	type Participant,
 	PARTICIPANTS_DIRECTORY
 } from '$lib/participants/participant-schema';
-import { parse } from 'jsonc-parser';
+import {
+	getLocation,
+	parse,
+	printParseErrorCode,
+	type ParseError
+} from 'jsonc-parser';
 import { join } from 'node:path';
+
+const JSONC_PARSE_OPTIONS = { allowTrailingComma: true } as const;
+
+function formatParseErrors(text: string, errors: ParseError[]): string {
+	return errors
+		.map((error) => {
+			const location = getLocation(text, error.offset);
+			const path = location.path.length > 0 ? location.path.join('.') : 'root';
+			return `\t${path}: ${printParseErrorCode(error.error)}`;
+		})
+		.join('\n');
+}
 
 export async function loadParticipantJsonFilePaths(directory: string): Promise<string[]> {
 	const participantsDirectory = await readdir(directory, {
@@ -47,7 +64,13 @@ export async function loadParticipants(filePaths: string[]): Promise<Participant
 
 export async function parseParticipantJson(filePath: string): Promise<Participant> {
 	const text = await readFile(filePath, 'utf-8');
-	const json = parse(text) as unknown;
+	const parseErrors: ParseError[] = [];
+	const json = parse(text, parseErrors, JSONC_PARSE_OPTIONS) as unknown;
+
+	if (parseErrors.length > 0) {
+		throw Error(`Invalid participant json '${filePath}':\n${formatParseErrors(text, parseErrors)}`);
+	}
+
 	const result = ParticipantSchema.safeParse(json);
 
 	if (!result.success) {


### PR DESCRIPTION
Extend participant file tests to fail on jsonc-parser parse errors, not just Zod schema validation

- Use allowTrailingComma: true so trailing commas in JSONC files (common when optional fields are commented out) remain valid
- Fix existing syntax errors in `ariadne.json` and `dan.json` uncovered by the stricter checks